### PR TITLE
Added software envelope generator.

### DIFF
--- a/include/sound.h
+++ b/include/sound.h
@@ -52,13 +52,14 @@
  * Each sound data stream shall be in the following format.
  *
  * \note
- * The following is written in BNF-like notation.
+ * The format of the sound data stream is described in the extended BNF format
+ * as follows:
  * - The term `x*` means zero or more `x`.
  * - The term `x+` means one or more `x`.
  * - If a term ends with `b` (e.g. `1111b`), it means a binary number.
  * - A `-` in a binary number means an unused bit.
  * - If a term ends with `:y` (e.g. `foo:5`), it means that the term is a binary
- *   number with y bits.
+ *   number with `y` bits.
  *
  * ~~~
  * stream = chunk* eom
@@ -67,26 +68,31 @@
  * eom    = 1111b 1111b
  *
  * header  = len:3 duration_hi:5 duration_lo:8
- * command = tone
- *         | rest
+ * command = keyon
+ *         | tone
+ *         | keyoff
  *         | volume
+ *         | software_envelope_pattern
  *         | envelope_pattern
  *         | envelope_cycle
  *         | envelope_pattern_and_cycle
  *         | noise
  *         | mixer
  *
- * tone   = 0000b fdr_hi:4 fdr_lo:8
- * rest   = 0001b ----b
- * noise  = 001b fdr:5
+ * keyon  = 0000b tone_fdr_hi:4 tone_fdr_lo:8
+ * tone   = 1110b tone_fdr_hi:4 tone_fdr_lo:8
+ * keyoff = 0001b ----b
+ * noise  = 001b noise_fdr:5
  * mixer  = 0111b ----b --b NC:1 NB:1 NA:1 TC:1 TB:1 TA:1
  * volume = 1000b vol:4
+ * software_envelope_pattern
+ *        = 1100b pat:4
  * envelope_pattern
  *        = 1001b pat:4
  * envelope_cycle
- *        = 0100b 0000b fdr_hi:8 fdr_lo:8
+ *        = 0100b 0000b cycle_hi:8 cycle_lo:8
  * envelope_pattern_and_cycle
- *        = 1101b pat:4 fdr_hi:8 fdr_lo:8
+ *        = 1101b pat:4 cycle_hi:8 cycle_lo:8
  * ~~~
  *
  * The structure of `chunk`:
@@ -155,6 +161,13 @@ struct sound_clip {
  * machine.
  */
 void sound_init(void);
+
+/**
+ * Set main volume level.
+ *
+ * \param volume   main volume level (0..15)
+ */
+void sound_set_volume(uint8_t volume);
 
 /**
  * Turn on/off the auto-repeat of the BGM.

--- a/include/sound_eg.h
+++ b/include/sound_eg.h
@@ -1,0 +1,111 @@
+// -*- coding: utf-8-unix -*-
+/**
+ * \file sound_eg.h
+ *
+ * Copyright (c) 2021 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project
+ * https://github.com/mori0091/libmsx
+ */
+
+#ifndef SOUND_EG_H
+#define SOUND_EG_H
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/** The maximum number of elements for the envelope generator attribute table. */
+#define SOUND_EG_TABLE_MAX   (16)
+
+/** The class identifier for AHDSR envelope generator */
+#define SOUND_EG_AHDSR       (0)
+/** The class identifier for LPCM envelope generator */
+#define SOUND_EG_LPCM        (1)
+
+/** Parameters for AHDSR envelope generator */
+struct sound_eg_AHDSR {
+  /** Asccendant velocity of attack phase. */
+  uint8_t attack_rate;
+  /** Period of hold phase. */
+  uint8_t hold_time;
+  /** Deccendant velocity of decay phase. */
+  uint8_t decay_rate;
+  /** Output level of sustain phase. */
+  uint8_t sustain_level;
+  /** desccendant velocity of release phase */
+  uint8_t release_rate;
+};
+
+/** Parameters for linear PCM (8-bit, 60Hz) envelope generator */
+struct sound_eg_LPCM {
+  /** number of sampled signal levels */
+  uint8_t len;
+  /** time series of the sampled signal levels (i.e. wave form) */
+  uint8_t * data;
+};
+
+/**
+ * Attributes of a software envelope generator object.
+ *
+ * The attribute consists of the following two parts:
+ * 1. an envelope generator class identifier `clz`
+ * 2. a set of parameter constants `param`
+ *
+ * The `clz` shall be one of the two classes:
+ * - `SOUND_EG_AHDSR` for AHDSR type envelope generator, or
+ * - `SOUND_EG_LPCM` for 8-bit 60Hz Linear PCM type envelope generator.
+ *
+ * The `param` shall be a pointer to parameter constants, and it has the
+ * following two strictly typed sinonym:
+ * - `ahdsr` of `const struct sound_eg_AHDSR *` type for AHDSR type envelope
+ *   generator.
+ * - `lpcm` of `const struct sound_eg_LPCM *` type for 8-bit 60Hz Linear PCM
+ *   type envelope generator.
+ */
+struct sound_eg_attribute {
+  /**
+   * The class identifier of this envelope generator.
+   */
+  uint8_t clz;
+  union {
+    /**
+     * Pointer to parameter constants for this instance.
+     */
+    void * param;
+    /**
+     * Pointer to parameter constants for this instance of the SOUND_EG_AHDSR
+     * class.
+     *
+     * This is a strictly typed sinonym for `param`.
+     */
+    const struct sound_eg_AHDSR * ahdsr;
+    /**
+     * Pointer to parameter constants for this instance of the SOUND_EG_LPCM
+     * class.
+     *
+     * This is a strictly typed sinonym for `param`.
+     */
+    const struct sound_eg_LPCM * lpcm;
+  };
+};
+
+/**
+ * (Re)set the software envelope generator attribute table.
+ *
+ * This function sets the base address of the software envelope generator table
+ * to the given address `table`, or reset to the default if `table` was `NULL`.
+ *
+ * The table should be an array of `struct sound_eg_attribute` with a maximum of
+ * 16 elements. Each element can contain the individual parameter settings of an
+ * envelope generator of type AHDSR or LPCM.
+ *
+ * \param table    base address of the attribute table.
+ */
+void sound_set_eg_table(const struct sound_eg_attribute * table);
+
+#endif

--- a/include/sound_eg_spi.h
+++ b/include/sound_eg_spi.h
@@ -1,0 +1,54 @@
+// -*- coding: utf-8-unix -*-
+/**
+ * \file sound_eg_spi.h
+ *
+ * Copyright (c) 2021 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project
+ * https://github.com/mori0091/libmsx
+ */
+#ifndef SOUND_EG_SPI_H
+#define SOUND_EG_SPI_H
+
+#pragma once
+
+#include "sound_eg.h"
+
+/**
+ * Software envelope generator object.
+ *
+ * \note
+ * This is used by the sound driver internally. Not for the user application.
+ */
+struct sound_eg {
+  /** class identifier and instance constants. */
+  struct sound_eg_attribute attr;
+  // instance fields
+  /** current output signal level of the envelope (0..255) */
+  uint8_t output;
+  /** identifier of current state */
+  uint8_t state;
+  /** elapsed time or remaining duration of current state */
+  uint8_t time;
+};
+
+/**
+ * Instance methods (set of function pointers) of software envelope generator
+ * objects.
+ *
+ * \note
+ * This is used by the sound driver internally. Not for the user application.
+ */
+struct sound_eg_vtbl {
+  /** Notify `key on` to the envelope generator. */
+  void (* key_on)(struct sound_eg * self);
+  /** Notify `key off` to the envelope generator. */
+  void (* key_off)(struct sound_eg * self);
+  /** Notifies the envelope generator that 1/60th of a second has elapsed. */
+  void (* advance)(struct sound_eg * self);
+};
+
+#endif

--- a/src/sound.c
+++ b/src/sound.c
@@ -16,85 +16,163 @@
 #include "../include/bios.h"
 #include "../include/psg.h"
 #include "../include/sound.h"
-
-// backup of PSG registers
-static uint8_t sound_psg_reg_backup[14];
+#include "../include/sound_eg.h"
+#include "../include/sound_eg_spi.h"
 
 #define COUNT_PER_SECOND    (300)
 #define COUNT_PER_TICK_60HZ (COUNT_PER_SECOND / 60)
 
-static uint16_t COUNT_PER_TICK;
+static uint8_t COUNT_PER_TICK;
 static uint8_t VSYNC_FREQ;
 
-struct channel {
+struct sound_channel {
+  /* sequence control */
   const uint8_t* next;          // pointer to next chunk for each streams
   int16_t duration;             // remaining duration for each channel
-  uint8_t volume;               // current volume for each channel
+  /* envelope generator */
+  struct sound_eg eg;
+  /* amplifier */
+  uint8_t amp;                  // 4 bits
+  /* Whether use the hardware envelope generator is enabled or not. */
+  bool hw_envelope_enable;
 };
 
 struct sound_state {
   const struct sound_clip* clip; // pointer to current music (set of streams)
-  struct channel channels[3];
-  uint8_t section;               // current fragment number
-  uint8_t flag;                  // playing/stopped flags
-  uint8_t envelope_pattern;      // current envelope pattern
+  struct sound_channel channels[3];
+  uint8_t section;              // current fragment number
+  uint8_t flag;                 // playing/stopped flags
+  uint8_t envelope_pattern;     // R#13 hardware envelope pattern (4 bits)
 };
 
 static struct {
-  // background music
-  struct {
-    struct sound_state state;   // state of background music
-    bool repeat;                // auto repeat on/off
-    bool paused;                // whether the BGM is paused or not.
-  } bg;
-  // sound effect
-  struct {
-    struct sound_state state;   // state of sound effect
-  } se;
+  bool repeat;                // auto repeat on/off
+  bool paused;                // whether the BGM is paused or not.
+  uint8_t volume;             // volume control (4 bits)
+  struct sound_state bg;      // state of background music
+  struct sound_state se;      // state of sound effect
 } sound;
 
-void sound_set_repeat(bool repeat) {
-  sound.bg.repeat = repeat;
+// -----
+
+static const struct sound_eg_AHDSR sound_eg_AHDSR_DEFAULT = {
+  .attack_rate = 255,
+  .hold_time = 0,
+  .decay_rate = 12,
+  .sustain_level = 0,
+  .release_rate = 255,
+};
+
+static const uint8_t lpcm_default[] = {255};
+static const struct sound_eg_LPCM sound_eg_LPCM_DEFAULT = {
+  .len = sizeof(lpcm_default),
+  .data = lpcm_default,
+};
+
+static const struct sound_eg_attribute sound_eg_table_default[] = {
+  [0] = {.clz = SOUND_EG_AHDSR, .param = &sound_eg_AHDSR_DEFAULT},
+  [1] = {.clz = SOUND_EG_LPCM , .param = &sound_eg_LPCM_DEFAULT },
+};
+
+static const struct sound_eg_attribute * sound_eg_table;
+
+uint8_t sound_tick;
+uint8_t sound_advance_count;
+
+extern const struct sound_eg_vtbl sound_eg_AHDSR;
+extern const struct sound_eg_vtbl sound_eg_LPCM;
+
+static const struct sound_eg_vtbl * sound_eg_classes[] = {
+  [SOUND_EG_AHDSR] = &sound_eg_AHDSR,
+  [SOUND_EG_LPCM] = &sound_eg_LPCM,
+};
+
+inline void sound_eg_key_on(struct sound_eg * self) {
+  sound_eg_classes[self->attr.clz]->key_on(self);
 }
 
-static void sound_psg_set(bool muted, uint8_t reg, uint8_t value) {
-  if (!muted) {
-    psg_set(reg, value);
-  }
-  else {
-    sound_psg_reg_backup[reg] = value;
+inline void sound_eg_key_off(struct sound_eg * self) {
+  sound_eg_classes[self->attr.clz]->key_off(self);
+}
+
+inline void sound_eg_advance(struct sound_eg * self) {
+  for (uint8_t i = 0; i < sound_advance_count; ++i) {
+    sound_eg_classes[self->attr.clz]->advance(self);
   }
 }
+
+inline void sound_update_tick(void) {
+  sound_tick += COUNT_PER_TICK;
+  sound_advance_count = 0;
+  while (COUNT_PER_TICK_60HZ <= sound_tick) {
+    sound_tick -= COUNT_PER_TICK_60HZ;
+    sound_advance_count++;
+  }
+}
+
+// -----
+
+void sound_set_eg_table(const struct sound_eg_attribute * table) {
+  sound_eg_table = table ? table : sound_eg_table_default;
+}
+
+static void sound_channel_set_envelope(struct sound_channel * sc, uint8_t index) {
+  sc->eg.attr.clz = sound_eg_table[index].clz;
+  sc->eg.attr.param = sound_eg_table[index].param;
+  sc->eg.output = 0;
+  sc->eg.state = 0;
+  sc->eg.time = 0;
+  sc->hw_envelope_enable = false;
+}
+
+inline void sound_channel_set_amp(struct sound_channel * sc, uint8_t amp) {
+  sc->amp = amp;
+}
+
+inline void sound_channel_enable_hw_envelope(struct sound_channel * sc) {
+  sc->hw_envelope_enable = true;
+}
+
+// -----
+
+void sound_set_repeat(bool repeat) {
+  sound.repeat = repeat;
+}
+
+static struct {
+  uint8_t noise_fdr;
+  uint8_t mixer;
+  uint8_t envelope_cycle_lo;
+  uint8_t envelope_cycle_hi;
+} backup;
 
 static void sound_backup_psg_registers(void) {
-  for (uint8_t i = 0; i <= 13; ++i) {
-    sound_psg_reg_backup[i] = psg_get(i);
-  }
+  backup.noise_fdr = psg_get(6);
+  backup.mixer = psg_get(7);
+  backup.envelope_cycle_lo = psg_get(11);
+  backup.envelope_cycle_hi = psg_get(12);
 }
 
 static void sound_restore_psg_registers(void) {
-  // tone, noise, and mixier
-  for (uint8_t i = 0; i <= 7; ++i) {
-    psg_set(i, sound_psg_reg_backup[i]);
-  }
-  // volume and/or envelope on/off
-  for (uint8_t i = 8; i <= 10; ++i) {
-    if (sound_psg_reg_backup[i] & 16) {
-      psg_set(i, 0);
-    } else {
-      psg_set(i, sound_psg_reg_backup[i]);
-    }
-  }
-  // envelope pattern and cycle
-  for (uint8_t i = 11; i <= 13; ++i) {
-    psg_set(i, sound_psg_reg_backup[i]);
-  }
+  sound.bg.channels[0].eg.output = 0; psg_set(8, 0);
+  sound.bg.channels[1].eg.output = 0; psg_set(9, 0);
+  sound.bg.channels[2].eg.output = 0; psg_set(10, 0);
+  psg_set(6, backup.noise_fdr);
+  psg_set(7, backup.mixer);
+  psg_set(11, backup.envelope_cycle_lo);
+  psg_set(12, backup.envelope_cycle_hi);
+}
+
+void sound_set_volume(uint8_t volume) {
+  sound.volume = (15 < volume ? 15 : volume);
 }
 
 void sound_set_mute(uint8_t mute) {
   mute &= 7;
-  sound.bg.state.flag &= ~(7 << 3);
-  sound.bg.state.flag |= mute << 3;
+  sound.bg.flag &= ~(7 << 3);
+  sound.bg.flag |= mute << 3;
+  sound.se.flag &= ~(7 << 3);
+  sound.se.flag |= mute << 3;
   if (mute & SOUND_CHANNEL_A) psg_set(8, 0);
   if (mute & SOUND_CHANNEL_B) psg_set(9, 0);
   if (mute & SOUND_CHANNEL_C) psg_set(10, 0);
@@ -111,28 +189,22 @@ static void sound_set_fragment(struct sound_state* st, const struct sound_fragme
   if (sf->streams[0] && *sf->streams[0] != 0xff) flag |= SOUND_CHANNEL_A;
   if (sf->streams[1] && *sf->streams[1] != 0xff) flag |= SOUND_CHANNEL_B;
   if (sf->streams[2] && *sf->streams[2] != 0xff) flag |= SOUND_CHANNEL_C;
-  __critical {
-    st->flag = flag;
-  }
+  st->flag = flag;
 }
 
 static void sound_set_clip(struct sound_state* st, const struct sound_clip* s) {
   if (!s || !s->fragments || 0 == s->num_fragments) {
-    __critical {
-      st->flag = 0;
-      st->clip = 0;
-    }
+    st->flag = 0;
+    st->clip = 0;
     return;
   }
   st->section = 0;
-  st->channels[0].volume = psg_reg_initial_vector[8];
-  st->channels[1].volume = psg_reg_initial_vector[9];
-  st->channels[2].volume = psg_reg_initial_vector[10];
+  st->channels[0].amp = psg_reg_initial_vector[8];
+  st->channels[1].amp = psg_reg_initial_vector[9];
+  st->channels[2].amp = psg_reg_initial_vector[10];
   const struct sound_fragment* sf = s->fragments[0];
   sound_set_fragment(st, sf);
-  __critical {
-    st->clip = s;
-  }
+  st->clip = s;
 }
 
 static volatile const struct sound_clip * next_sound_effect;
@@ -146,175 +218,254 @@ static void sound_effect_apply(void) {
   const struct sound_clip * s = next_sound_effect;
   next_sound_effect = NULL;
   if (!s) return;
-  if (sound.se.state.flag & SOUND_CHANNEL_ALL) {
-    if (s->priority < sound.se.state.clip->priority) {
+  if (sound.se.flag & SOUND_CHANNEL_ALL) {
+    if (s->priority < sound.se.clip->priority) {
       return;
     }
   }
-  if (!sound.se.state.clip) {
-    // BGM may be playing, so takes snapshot of register values.
-    sound_backup_psg_registers();
-  }
-  else {
+  if (sound.se.clip) {
     // When switching sound effects, using channels may differ between previous
     // and next sound effects, so temporally restores register values for BGM
     // before playing the next sound effects.
     sound_restore_psg_registers();
   }
-  sound_set_clip(&sound.se.state, s);
+  else {
+    sound_backup_psg_registers();
+  }
+  sound_set_clip(&sound.se, s);
 }
 
 void sound_set_bgm(const struct sound_clip* s) {
   sound_stop();
   sound_pause();
-  if (s) {
-    sound_set_clip(&sound.bg.state, s);
+  if (!s) {
+    return;
+  }
+  __critical {
+    sound_set_clip(&sound.bg, s);
   }
 }
 
 void sound_start(void) {
-  sound.bg.paused = false;
+  sound.paused = false;
+}
+
+static void sound_state_init(struct sound_state * st) {
+  st->clip = 0;
+  st->flag = 0;
+  // ----
+  for (uint8_t ch = 0; ch < 3; ++ch) {
+    sound_channel_set_envelope(&st->channels[ch], 0);
+    sound_channel_set_amp(&st->channels[ch], psg_reg_initial_vector[8+ch]);
+  }
+  st->envelope_pattern = psg_reg_initial_vector[13];
 }
 
 void sound_init(void) {
-  sound_effect(NULL);
-  sound_pause();
   VSYNC_FREQ = msx_get_vsync_frequency();
   COUNT_PER_TICK = COUNT_PER_SECOND / VSYNC_FREQ;
-  psg_init();
-  sound.bg.state.clip = 0;
-  sound.bg.state.flag = 0;
-  sound.se.state.clip = 0;
-  sound.se.state.flag = 0;
-  memcpy(sound_psg_reg_backup,
-         psg_reg_initial_vector,
-         sizeof(psg_reg_initial_vector));
+  sound_eg_table = sound_eg_table_default;
+  sound_set_volume(15);
+  sound_stop();
 }
 
 void sound_stop(void) {
-  sound_init();
+  sound_effect(NULL);
+  sound_pause();
+  psg_init();
+  sound_state_init(&sound.bg);
+  sound_state_init(&sound.se);
+  sound_tick = 0;
 }
 
 void sound_pause(void) {
-  sound.bg.paused = true;
+  sound.paused = true;
   psg_set(8, 0);
   psg_set(9, 0);
   psg_set(10, 0);
 }
 
-static void sound_player__process_chunk(struct sound_state* st, const uint8_t flag) {
-  uint8_t mask = SOUND_CHANNEL_A;
-  for (uint8_t ch = 0; ch < 3; ++ch, mask <<= 1) {
-    struct channel * stch = &st->channels[ch];
-    // ---- Countdown time remaining ----
+// ---- local work area for `sound_player()` ----
+static struct sound_state* st;
+static uint8_t mute;
+
+static void sound_channel_output(const uint8_t ch,
+                                 const struct sound_channel * stch) {
+  // if using hardware envelope, it shall be treated specially.
+  // otherwise, the amplitude is controlled by software envelope.
+  const uint8_t x = ((uint16_t)stch->eg.output *
+                     (stch->amp + 1) *
+                     (sound.volume + 1)) >> 12;
+  psg_set(8+ch, x);
+}
+
+inline void sound_player__process_channel(const uint8_t ch, const uint8_t mask) {
+  const bool channel_muted = (bool)(mute & (mask << 3));
+  struct sound_channel * const stch = &st->channels[ch];
+  // advance the channel's envelope generator by 1/60th a second.
+  sound_eg_advance(&stch->eg);
+  // ---- Countdown time remaining ----
+  {
+    stch->duration -= COUNT_PER_TICK;
     if (0 < stch->duration) {
-      stch->duration -= COUNT_PER_TICK;
-      if (0 < stch->duration) {
-        continue;
+      if (!channel_muted && !stch->hw_envelope_enable) {
+        sound_channel_output(ch, stch);
       }
+      return;
     }
-    // ---- Check to see if the stream has finished. ----
-    if (!(st->flag & mask)) continue; // no more chunk
+  }
+  // ---- Reads head (chunk size and next duration) ----
+  uint8_t len;
+  {
     const uint8_t head1 = *stch->next++;
     if (head1 == 255) {
       // end of music track
       st->flag &= ~mask;
-      continue;
+      if (!channel_muted && !stch->hw_envelope_enable) {
+        sound_channel_output(ch, stch);
+      }
+      return;
     }
-    // ---- Reads head (chunk size and next duration) ----
-    uint8_t len = (head1 >> 5) & 7;
     const uint16_t ticks = ((head1 & 0x1f) << 8) | (*stch->next++);
     stch->duration += COUNT_PER_TICK_60HZ * ticks;
-    // ---- Parse and process the chunk ----
-    const bool muted = flag & (mask << 3); // \note Using `flag` instead of `st->flag`
-    while (len) {
-      len--;
-      const uint8_t x = *stch->next++;
-      const uint8_t x_lo = x & 0x0f;
-      switch (x & 0xf0) {
-      case 0x00:
-        // tone (12bits)
-        // 0000b fdr_hi:4 fdr_lo:8
-        sound_psg_set(muted, 1+2*ch, x_lo);          // fdr_hi:4
-        sound_psg_set(muted, 0+2*ch, *stch->next++); // fdr_lo:8
-        // "note on"
-        {
-          if (16 & stch->volume) {
-            // (re)set hardware envelope
-            sound_psg_set(muted, 13, st->envelope_pattern);
-            sound_psg_set(muted, 8+ch, stch->volume);
-          }
-          else {
-            // (re)set software envelope
-            // \TODO implement software envelope functionality
-          }
-        }
+    len = (head1 >> 5) & 7;
+  }
+  // ---- Parse and process the chunk ----
+  while (len--) {
+    const uint8_t x = *stch->next++;
+    const uint8_t x_lo = x & 0x0f;
+    switch (x & 0xf0) {
+    case 0xe0:
+      // tone (12bits)
+      // 1110b fdr_hi:4 fdr_lo:8
+      // -- changes frequency of tone generator but do not key-on.
+      {
+        const uint8_t x_hi = *stch->next++;
         len--;
-        break;
-      case 0x10:
-        // rest (0bits)
-        sound_psg_set(muted, 8+ch, 0);
-        break;
-      case 0x20:
-      case 0x30:
-        // noise (5bits)
-        // 001b fdr:5
-        sound_psg_set(muted, 6, x & 0x1f);
-        break;
-      case 0x70:
-        // mixer (6bits)
-        // 0111b ----b --b NC:1 NB:1 NA:1 TC:1 TB:1 TA:1
-        sound_psg_set(muted, 7, (*stch->next++ & 0x3f) | 0x80);
-        break;
-      case 0x80:
-        // volume (4bits)
-        // 1000b vol:4
-        sound_psg_set(muted, 8+ch, x_lo);
-        stch->volume = x_lo;
-        break;
-      case 0x40:
-      case 0x90:
-      case 0xd0:
-        if (x & 0x90) {
-          // envelope pattern (4bits)
-          // 1-01b pat:4
-          // \note
-          // The envelope pattern and switch states are saved (not applied to
-          // the registers here) and applied at each "note on" timing.
-          st->envelope_pattern = x_lo; // envelope pattern
-          stch->volume |= 16;     // turn on hardware envelope
+        if (!channel_muted) {
+          psg_set(1+2*ch, x_lo);    // fdr_hi:4
+          psg_set(0+2*ch, x_hi);    // fdr_lo:8
         }
-        if (x & 0x40) {
-          // envelope cycle (16bits)
-          // -10-b ----b fdr_hi:8 fdr_lo:8
-          sound_psg_set(muted, 12, *stch->next++); // cyble_hi:8
-          sound_psg_set(muted, 11, *stch->next++); // cycle_lo:8
-          len -= 2;
-        }
-        break;
-      default:
-        // stream error
-        len = 0;
-        st->flag &= ~mask;
-        break;
       }
+      break;
+    case 0x00:
+      // keyon (12bits)
+      // 0000b fdr_hi:4 fdr_lo:8
+      // -- Changes frequency of tone generator and performs a key-on.
+      {
+        const uint8_t x_hi = *stch->next++;
+        len--;
+        if (!channel_muted) {
+          psg_set(1+2*ch, x_lo);    // fdr_hi:4
+          psg_set(0+2*ch, x_hi);    // fdr_lo:8
+          // When using hardware envelopes, special processing is required.
+          if (stch->hw_envelope_enable) {
+            psg_set(13, st->envelope_pattern);
+            psg_set(8+ch, 16);
+          }
+        }
+        sound_eg_key_on(&stch->eg);
+      }
+      break;
+    case 0x10:
+      // keyoff (0bits)
+      // -- Perform a key-off. (It also serves as a rest.)
+      sound_eg_key_off(&stch->eg);
+      if (stch->hw_envelope_enable && !channel_muted) {
+        psg_set(8+ch, 0);
+      }
+      break;
+    case 0x20:
+    case 0x30:
+      // noise (5bits)
+      // 001b fdr:5
+      // -- Changes frequency of noise generator.
+      if (!channel_muted) {
+        psg_set(6, (x & 0x1f));
+      }
+      break;
+    case 0x70:
+      // mixer (6bits)
+      // 0111b ----b --b NC:1 NB:1 NA:1 TC:1 TB:1 TA:1
+      // -- Changes the mixer setting.
+      {
+        const uint8_t mixer = (*stch->next++ & 0x3f) | 0x80;
+        len--;
+        if (!channel_muted) {
+          psg_set(7, mixer);
+        }
+      }
+      break;
+    case 0x80:
+      // volume (4bits)
+      // 1000b vol:4
+      // -- Changes the amplifier level.
+      stch->amp = x_lo;
+      stch->hw_envelope_enable = false;
+      break;
+    case 0xc0:
+      // software envelope pattern (4bits)
+      // 1100b pat:4
+      // -- Set the software envelope pattern.
+      sound_channel_set_envelope(stch, x_lo);
+      stch->hw_envelope_enable = false;
+      break;
+    case 0x40:
+    case 0x90:
+    case 0xd0:
+      if (x & 0x90) {
+        // envelope pattern (4bits)
+        // 1-01b pat:4
+        // -- Set the hardware envelope pattern, and enable hardware envelope.
+        // The envelope pattern and switch states are saved (not applied to
+        // the registers here) and applied at each "key on" timing.
+        st->envelope_pattern = x_lo;
+        stch->hw_envelope_enable = true;
+      }
+      if (x & 0x40) {
+        // envelope cycle (16bits)
+        // -10-b ----b fdr_hi:8 fdr_lo:8
+        // -- Set the hardware envelope cycle.
+        const uint8_t cycle_hi = *stch->next++;
+        const uint8_t cycle_lo = *stch->next++;
+        len -= 2;
+        if (!channel_muted) {
+          psg_set(12, cycle_hi); // cycle_hi:8
+          psg_set(11, cycle_lo); // cycle_lo:8
+        }
+      }
+      break;
+    default:
+      // stream error
+      len = 0;
+      st->flag &= ~mask;
+      break;
     }
+  }
+  if (!channel_muted && !stch->hw_envelope_enable) {
+    sound_channel_output(ch, stch);
   }
 }
 
-static bool sound_player__process(struct sound_state* st, uint8_t mute) {
+static bool sound_player__process(void) {
   for (;;) {
-    sound_player__process_chunk(st, st->flag | mute);
+    {
+      uint8_t mask = SOUND_CHANNEL_A;
+      for (uint8_t ch = 0; ch < 3; ++ch, mask <<= 1) {
+        if (st->flag & mask) {
+          sound_player__process_channel(ch, mask);
+        }
+      }
+    }
     if (st->flag & SOUND_CHANNEL_ALL) {
       // current fragment is not finished.
       return false;
     }
-    if (st->section + 1 >= st->clip->num_fragments) {
+    if (++st->section >= st->clip->num_fragments) {
       // end of the clip
       return true;
     }
     // the clip has more fragments
-    st->section++;
     const struct sound_fragment * sf = st->clip->fragments[st->section];
     if (sf) {
       // set the next fragment
@@ -329,25 +480,34 @@ static bool sound_player__process(struct sound_state* st, uint8_t mute) {
 }
 
 void sound_player(void) {
+  if (sound.paused) {
+    return;
+  }
   sound_effect_apply();
+  sound_update_tick();
   // ---- sound effect ----
-  if (sound.se.state.clip) {
-    bool finished = sound_player__process(&sound.se.state, 0);
-    if (finished) {
-      sound.se.state.clip = 0;
+  if (sound.se.clip) {
+    st = &sound.se;
+    // mute = sound.se.flag & (7 << 3);
+    mute = sound.se.flag;
+    if (sound_player__process()) {
+      // ---- end of music ----
+      sound.se.clip = 0;
       sound_restore_psg_registers();
     }
   }
   // ---- background music ----
-  if (!sound.bg.paused && sound.bg.state.clip) {
+  if (sound.bg.clip) {
     // By passing `mute` as 2nd argument, temporarily turn on the mute switch
     // for the channel being used for sound effects.
-    bool finished = sound_player__process(&sound.bg.state,
-                                          (sound.se.state.flag << 3));
-    // ---- auto-repeat ----
-    if (finished) {
-      if (sound.bg.repeat) {
-        sound_set_bgm(sound.bg.state.clip);
+    st = &sound.bg;
+    // mute = (sound.bg.flag & (7 << 3)) | ((sound.se.flag & 7) << 3);
+    mute = sound.bg.flag | (sound.se.flag << 3);
+    if (sound_player__process()) {
+      // ---- end of music ----
+      if (sound.repeat) {
+        // ---- auto-repeat ----
+        sound_set_bgm(sound.bg.clip);
         sound_start();
       }
     }

--- a/src/sound_eg_AHDSR.c
+++ b/src/sound_eg_AHDSR.c
@@ -1,0 +1,118 @@
+// -*- coding: utf-8-unix -*-
+/**
+ * \file sound_eg_AHDSR.c
+ *
+ * Copyright (c) 2021 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project
+ * https://github.com/mori0091/libmsx
+ */
+
+#include "../include/sound_eg_spi.h"
+
+#define END_OF_PHASE  (0)
+#define ATTACK_PHASE  (1)
+#define HOLD_PHASE    (2)
+#define DECAY_PHASE   (3)
+#define SUSTAIN_PHASE (4)
+#define RELEASE_PHASE (5)
+
+#define ATTACK_RATE   (self->attr.ahdsr->attack_rate)
+#define HOLD_TIME     (self->attr.ahdsr->hold_time)
+#define DECAY_RATE    (self->attr.ahdsr->decay_rate)
+#define SUSTAIN_LEVEL (self->attr.ahdsr->sustain_level)
+#define RELEASE_RATE  (self->attr.ahdsr->release_rate)
+
+static void attack_phase(struct sound_eg * self) {
+  if (ATTACK_RATE < 255 - self->output) {
+    self->output += ATTACK_RATE;
+    return;
+  }
+  self->output = 255;
+  if (HOLD_TIME) {
+    self->time = HOLD_TIME;
+    self->state = HOLD_PHASE;
+  }
+  else {
+    self->state = DECAY_PHASE;
+  }
+}
+
+static void hold_phase(struct sound_eg * self) {
+  if (!self->time--) {
+    self->state = DECAY_PHASE;
+  }
+}
+
+static void decay_phase(struct sound_eg * self) {
+  if (DECAY_RATE < self->output) {
+    self->output -= DECAY_RATE;
+  }
+  else {
+    self->output = 0;
+  }
+  if (self->output <= SUSTAIN_LEVEL) {
+    self->output = SUSTAIN_LEVEL;
+    self->state = SUSTAIN_PHASE;
+  }
+}
+
+static void sustain_phase(struct sound_eg * self) {
+  // nothing to do
+  ((void)self);
+}
+
+static void release_phase(struct sound_eg * self) {
+  if (RELEASE_RATE < self->output) {
+    self->output -= RELEASE_RATE;
+    return;
+  }
+  self->output = 0;
+  self->state = END_OF_PHASE;
+}
+
+// ----
+
+static void sound_eg_AHDSR_key_on(struct sound_eg * self) {
+  self->state = ATTACK_PHASE;
+  self->output = 0;
+  attack_phase(self);
+}
+
+static void sound_eg_AHDSR_key_off(struct sound_eg * self) {
+  self->state = RELEASE_PHASE;
+  release_phase(self);
+}
+
+static void sound_eg_AHDSR_advance(struct sound_eg * self) {
+  switch (self->state) {
+  case END_OF_PHASE:
+    return;
+  case ATTACK_PHASE:
+    attack_phase(self);
+    return;
+  case HOLD_PHASE:
+    hold_phase(self);
+    return;
+  case DECAY_PHASE:
+    decay_phase(self);
+    return;
+  case SUSTAIN_PHASE:
+    sustain_phase(self);
+    return;
+  case RELEASE_PHASE:
+    release_phase(self);
+    return;
+  default:
+    return;
+  }
+}
+
+const struct sound_eg_vtbl sound_eg_AHDSR = {
+  .key_on  = sound_eg_AHDSR_key_on,
+  .key_off = sound_eg_AHDSR_key_off,
+  .advance = sound_eg_AHDSR_advance,
+};

--- a/src/sound_eg_LPCM.c
+++ b/src/sound_eg_LPCM.c
@@ -1,0 +1,44 @@
+// -*- coding: utf-8-unix -*-
+/**
+ * \file sound_eg_LPCM.c
+ *
+ * Copyright (c) 2021 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project
+ * https://github.com/mori0091/libmsx
+ */
+
+#include "../include/sound_eg_spi.h"
+
+#define LENGTH    (self->attr.lpcm->len)
+#define DATA      (self->attr.lpcm->data)
+
+static void update(struct sound_eg * self) {
+  if (LENGTH <= self->time) {
+    return;
+  }
+  self->output = DATA[self->time++];
+}
+
+static void sound_eg_LPCM_key_on(struct sound_eg * self) {
+  self->time = 0;
+  update(self);
+}
+
+static void sound_eg_LPCM_key_off(struct sound_eg * self) {
+  self->time = LENGTH;
+  update(self);
+}
+
+static void sound_eg_LPCM_advance(struct sound_eg * self) {
+  update(self);
+}
+
+const struct sound_eg_vtbl sound_eg_LPCM = {
+  .key_on  = sound_eg_LPCM_key_on,
+  .key_off = sound_eg_LPCM_key_off,
+  .advance = sound_eg_LPCM_advance,
+};


### PR DESCRIPTION
Added software envelope generator functionality to the sound driver.
- Supports two type of envelope generator
  - AHDSR (attack / hold / decay / sustain / release) type envelope generator
  - LPCM (8-bit 60Hz linear PCM) type envelope generator
- added `sound_set_eg_table()` for setting user-defined envelope patterns w/ up to 16 patterns
- added / changed some sound data stream commands
  - `keyon` for setting frequency of tone generator w/ perform key-on. (renamed from `tone`)
  - `tone` for setting frequency of tone generator w/o perform key-on.
  - `keyoff` to perform key-off (renamed from `rest`)
  - `software_envelope_pattern` for setting software envelope pattern number.