### PR TITLE
fix!: removed or replaced __critical with DI/EI.

### DIFF
--- a/src/ay_3_8910.c
+++ b/src/ay_3_8910.c
@@ -24,25 +24,23 @@ void ay_3_8910_init(void) {
 }
 
 void ay_3_8910_play(void) {
-  __critical {
-    {
-      uint8_t x = ay_3_8910_buffer[7];
-      x &= 0x3f;
-      x |= 0x80;
-      ay_3_8910_buffer[7] = x;
-    }
-    uint8_t * p = ay_3_8910_buffer;
-    uint8_t reg = 0;
-    /* R#0..R#10 */
-    while (reg < 11) {
-      psg_set(reg++, *p++);
-    }
-    /* R#11..R#13 */
-    if (ay_3_8910_buffer[13] < 16) {
-      psg_set(reg++, *p++);
-      psg_set(reg++, *p++);
-      psg_set(reg++, *p++);
-    }
-    ay_3_8910_buffer[13] = 0xff;
+  {
+    uint8_t x = ay_3_8910_buffer[7];
+    x &= 0x3f;
+    x |= 0x80;
+    ay_3_8910_buffer[7] = x;
   }
+  uint8_t * p = ay_3_8910_buffer;
+  uint8_t reg = 0;
+  /* R#0..R#10 */
+  while (reg < 11) {
+    psg_set(reg++, *p++);
+  }
+  /* R#11..R#13 */
+  if (ay_3_8910_buffer[13] < 16) {
+    psg_set(reg++, *p++);
+    psg_set(reg++, *p++);
+    psg_set(reg++, *p++);
+  }
+  ay_3_8910_buffer[13] = 0xff;
 }

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -72,15 +72,15 @@ void libmsx___init_intr(void) {
 }
 
 void set_interrupt_handler(void (*handler)(void)) {
-  __critical {
-    interrupt_handler = (handler ? handler : null_handler);
-  }
+  __asm__("di");
+  interrupt_handler = (handler ? handler : null_handler);
+  __asm__("ei");
 }
 
 void set_vsync_handler(void (*handler)(void)) {
-  __critical {
-    vsync_handler = (handler ? handler : null_handler);
-  }
+  __asm__("di");
+  vsync_handler = (handler ? handler : null_handler);
+  __asm__("ei");
 }
 
 void await_vsync(void) {

--- a/src/joypad_get_state.c
+++ b/src/joypad_get_state.c
@@ -38,21 +38,21 @@
 //   }
 //   for (;;) {
 //     volatile uint8_t x;
-//     __critical {
+//     __asm__("di");
 //       psg_set(15, r15 | KANA_LAMP_OFF);
 //       x = psg_get(14);
 //       // bit #3..#0 of PSG port B (PSG #15) shall be H level
 //       // during the PSG port B is not used for output.
 //       // (see MSX Datapack Volume 1, pp.44)
 //       psg_set(15, 0x0f | KANA_LAMP_OFF);
-//     }
+//     __asm__("ei");
 //     if (r14 == x) break;
 //     r14 = x;
 //   }
 //   return (~r14 & 0x3f);
 // }
 
-static const uint8_t lot[] = {
+static const uint8_t lut[] = {
   [0] = 0,
   [1] = VK_UP,
   [2] = VK_UP   | VK_RIGHT,
@@ -68,16 +68,16 @@ uint8_t joypad_get_state(uint8_t controller) {
   uint8_t joy;
   switch (controller) {
   case 0:
-    joy = lot[msx_GTSTCK(0)];
+    joy = lut[msx_GTSTCK(0)];
     joy |= msx_GTTRIG(0) & VK_FIRE_0;
     return joy;
   case 1:
-    joy = lot[msx_GTSTCK(1)];
+    joy = lut[msx_GTSTCK(1)];
     joy |= msx_GTTRIG(1) & VK_FIRE_0;
     joy |= msx_GTTRIG(3) & VK_FIRE_1;
     return joy;
   case 2:
-    joy = lot[msx_GTSTCK(2)];
+    joy = lut[msx_GTSTCK(2)];
     joy |= msx_GTTRIG(2) & VK_FIRE_0;
     joy |= msx_GTTRIG(4) & VK_FIRE_1;
     return joy;

--- a/src/psg_init.c
+++ b/src/psg_init.c
@@ -27,9 +27,9 @@ const uint8_t psg_reg_initial_vector[14] = {
 };
 
 void psg_init(void) {
-  __critical {
-    for (uint8_t i = 0; i < sizeof(psg_reg_initial_vector); ++i) {
-      psg_set(i, psg_reg_initial_vector[i]);
-    }
+  __asm__("di");
+  for (uint8_t i = 0; i < sizeof(psg_reg_initial_vector); ++i) {
+    psg_set(i, psg_reg_initial_vector[i]);
   }
+  __asm__("ei");
 }

--- a/src/vdp_cmd_execute.c
+++ b/src/vdp_cmd_execute.c
@@ -15,9 +15,9 @@
 
 static void vdp_cmd_exec_r32(const struct vdp_cmd * c, enum vdp_cmd_op opcode) {
   vdp_cmd_await();
-  __critical {
-    VDP_SET_CONTROL_REGISTER_POINTER_AUTO_INCREMENT(32);
-  }
+  __asm__("di");
+  VDP_SET_CONTROL_REGISTER_POINTER_AUTO_INCREMENT(32);
+  __asm__("ei");
   const uint8_t * p = &c->r32;
   VDP_SET_CONTROL_REGISTER_VALUE(*p++);
   VDP_SET_CONTROL_REGISTER_VALUE(*p++);
@@ -38,9 +38,9 @@ static void vdp_cmd_exec_r32(const struct vdp_cmd * c, enum vdp_cmd_op opcode) {
 
 static void vdp_cmd_exec_r36(const struct vdp_cmd * c, enum vdp_cmd_op opcode) {
   vdp_cmd_await();
-  __critical {
-    VDP_SET_CONTROL_REGISTER_POINTER_AUTO_INCREMENT(36);
-  }
+  __asm__("di");
+  VDP_SET_CONTROL_REGISTER_POINTER_AUTO_INCREMENT(36);
+  __asm__("ei");
   const uint8_t * p = &c->r36;
   VDP_SET_CONTROL_REGISTER_VALUE(*p++);
   VDP_SET_CONTROL_REGISTER_VALUE(*p++);

--- a/src/vdp_cmd_set_unrestricted.c
+++ b/src/vdp_cmd_set_unrestricted.c
@@ -16,12 +16,12 @@
 #include "vdp_internal.h"
 
 void vdp_cmd_set_unrestricted(bool enable) {
-  __critical {
-    if (enable) {
-      RG25SA |= 0x40;
-    } else {
-      RG25SA &= ~0x40;
-    }
-    VDP_SET_CONTROL_REGISTER(25, RG25SA);
+  __asm__("di");
+  if (enable) {
+    RG25SA |= 0x40;
+  } else {
+    RG25SA &= ~0x40;
   }
+  VDP_SET_CONTROL_REGISTER(25, RG25SA);
+  __asm__("ei");
 }

--- a/src/vdp_get_status.c
+++ b/src/vdp_get_status.c
@@ -17,10 +17,10 @@
 
 uint8_t vdp_get_status(uint8_t reg) {
   volatile uint8_t x;
-  __critical {
-    VDP_SET_STATUS_REGISTER_POINTER(reg);
-    x = VDP_GET_STATUS_REGISTER_VALUE();
-    VDP_SET_STATUS_REGISTER_POINTER(0);
-  }
+  __asm__("di");
+  VDP_SET_STATUS_REGISTER_POINTER(reg);
+  x = VDP_GET_STATUS_REGISTER_VALUE();
+  VDP_SET_STATUS_REGISTER_POINTER(0);
+  __asm__("ei");
   return x;
 }

--- a/src/vdp_set_adjust.c
+++ b/src/vdp_set_adjust.c
@@ -22,8 +22,8 @@ void vdp_set_adjust(int8_t x, int8_t y) {
   if (8 < y) y = 8;
   x = (0 < x) ? 16 - x : -x;
   y = (0 < y) ? 16 - y : -y;
-  __critical {
-    RG18SA = (y << 4) | x;
-    VDP_SET_CONTROL_REGISTER(18, RG18SA);
-  }
+  __asm__("di");
+  RG18SA = (y << 4) | x;
+  VDP_SET_CONTROL_REGISTER(18, RG18SA);
+  __asm__("ei");
 }

--- a/src/vdp_set_color.c
+++ b/src/vdp_set_color.c
@@ -16,8 +16,8 @@
 #include "vdp_internal.h"
 
 void vdp_set_color(uint8_t c) {
-  __critical {
-    RG7SAV = c;
-    VDP_SET_CONTROL_REGISTER(7, c);
-  }
+  __asm__("di");
+  RG7SAV = c;
+  VDP_SET_CONTROL_REGISTER(7, c);
+  __asm__("ei");
 }

--- a/src/vdp_set_color_table.c
+++ b/src/vdp_set_color_table.c
@@ -19,36 +19,36 @@ void vdp_set_color_table(vmemptr_t table) {
   uint8_t r3;
   uint8_t r10;
   switch (screen_mode) {
-  case VDP_SCREEN_MODE_TEXT_1:
-    return;
-  case VDP_SCREEN_MODE_TEXT_2:
-    r3 = ((table >> 6) & 0xFF) | 0x07;
-    r10 = (table >> 14) & 0x07;
-    break;
-  case VDP_SCREEN_MODE_MULTI_COLOR:
-    return;
-  case VDP_SCREEN_MODE_GRAPHIC_1:
-    r3 = (table >> 6) & 0xFF;
-    r10 = (table >> 14) & 0x07;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_2:
-  case VDP_SCREEN_MODE_GRAPHIC_3:
-    r3 = ((table >> 6) & 0xFF) | 0x7F;
-    r10 = (table >> 14) & 0x07;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_4:
-  case VDP_SCREEN_MODE_GRAPHIC_5:
-  case VDP_SCREEN_MODE_GRAPHIC_6:
-  case VDP_SCREEN_MODE_GRAPHIC_7:
-  default:
-    return;
+    case VDP_SCREEN_MODE_TEXT_1:
+      return;
+    case VDP_SCREEN_MODE_TEXT_2:
+      r3 = ((table >> 6) & 0xFF) | 0x07;
+      r10 = (table >> 14) & 0x07;
+      break;
+    case VDP_SCREEN_MODE_MULTI_COLOR:
+      return;
+    case VDP_SCREEN_MODE_GRAPHIC_1:
+      r3 = (table >> 6) & 0xFF;
+      r10 = (table >> 14) & 0x07;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_2:
+    case VDP_SCREEN_MODE_GRAPHIC_3:
+      r3 = ((table >> 6) & 0xFF) | 0x7F;
+      r10 = (table >> 14) & 0x07;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_4:
+    case VDP_SCREEN_MODE_GRAPHIC_5:
+    case VDP_SCREEN_MODE_GRAPHIC_6:
+    case VDP_SCREEN_MODE_GRAPHIC_7:
+    default:
+      return;
   }
-  __critical {
-    RG3SAV = r3;
-    VDP_SET_CONTROL_REGISTER(3, RG3SAV);
-    if (0 < msx_get_version()) {
-      RG10SA = r10;
-      VDP_SET_CONTROL_REGISTER(10, RG10SA);
-    }
+  __asm__("di");
+  RG3SAV = r3;
+  VDP_SET_CONTROL_REGISTER(3, RG3SAV);
+  if (0 < msx_get_version()) {
+    RG10SA = r10;
+    VDP_SET_CONTROL_REGISTER(10, RG10SA);
   }
+  __asm__("ei");
 }

--- a/src/vdp_set_control.c
+++ b/src/vdp_set_control.c
@@ -16,7 +16,7 @@
 #include "vdp_internal.h"
 
 void vdp_set_control(uint8_t reg, uint8_t x) {
-  __critical {
-    VDP_SET_CONTROL_REGISTER(reg, x);
-  }
+  __asm__("di");
+  VDP_SET_CONTROL_REGISTER(reg, x);
+  __asm__("ei");
 }

--- a/src/vdp_set_hscroll.c
+++ b/src/vdp_set_hscroll.c
@@ -19,10 +19,10 @@ void vdp_set_hscroll(uint16_t x) {
   uint8_t r26 = (x >> 3) & 0x3f;
   uint8_t r27 = (~x + 1) & 0x07;
   if (r27) r26++;
-  __critical {
-    RG26SA = r26;
-    RG27SA = r27;
-    VDP_SET_CONTROL_REGISTER(26, r26);
-    VDP_SET_CONTROL_REGISTER(27, r27);
-  }
+  __asm__("di");
+  RG26SA = r26;
+  RG27SA = r27;
+  VDP_SET_CONTROL_REGISTER(26, r26);
+  VDP_SET_CONTROL_REGISTER(27, r27);
+  __asm__("ei");
 }

--- a/src/vdp_set_hscroll_dual_page.c
+++ b/src/vdp_set_hscroll_dual_page.c
@@ -16,12 +16,12 @@
 #include "vdp_internal.h"
 
 void vdp_set_hscroll_dual_page(bool enable) {
-  __critical {
-    if (enable) {
-      RG25SA |= 0x01;
-    } else {
-      RG25SA &= ~0x01;
-    }
-    VDP_SET_CONTROL_REGISTER(25, RG25SA);
+  __asm__("di");
+  if (enable) {
+    RG25SA |= 0x01;
+  } else {
+    RG25SA &= ~0x01;
   }
+  VDP_SET_CONTROL_REGISTER(25, RG25SA);
+  __asm__("ei");
 }

--- a/src/vdp_set_hscroll_mask.c
+++ b/src/vdp_set_hscroll_mask.c
@@ -16,12 +16,12 @@
 #include "vdp_internal.h"
 
 void vdp_set_hscroll_mask(bool enable) {
-  __critical {
-    if (enable) {
-      RG25SA |= 0x02;
-    } else {
-      RG25SA &= ~0x02;
-    }
-    VDP_SET_CONTROL_REGISTER(25, RG25SA);
+  __asm__("di");
+  if (enable) {
+    RG25SA |= 0x02;
+  } else {
+    RG25SA &= ~0x02;
   }
+  VDP_SET_CONTROL_REGISTER(25, RG25SA);
+  __asm__("ei");
 }

--- a/src/vdp_set_image_table.c
+++ b/src/vdp_set_image_table.c
@@ -18,29 +18,29 @@
 void vdp_set_image_table(vmemptr_t table) {
   uint8_t r2;
   switch (screen_mode) {
-  case VDP_SCREEN_MODE_TEXT_2:
-    r2 = ((table >> 10) & 0x7F) | 0x03;
-    break;
-  case VDP_SCREEN_MODE_TEXT_1:
-  case VDP_SCREEN_MODE_MULTI_COLOR:
-  case VDP_SCREEN_MODE_GRAPHIC_1:
-  case VDP_SCREEN_MODE_GRAPHIC_2:
-  case VDP_SCREEN_MODE_GRAPHIC_3:
-    r2 = (table >> 10) & 0x7F;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_4:
-  case VDP_SCREEN_MODE_GRAPHIC_5:
-    r2 = ((table >> 10) & 0x7F) | 0x1F;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_6:
-  case VDP_SCREEN_MODE_GRAPHIC_7:
-    r2 = ((table >> 11) & 0x3F) | 0x1F;
-    break;
-  default:
-    return;
+    case VDP_SCREEN_MODE_TEXT_2:
+      r2 = ((table >> 10) & 0x7F) | 0x03;
+      break;
+    case VDP_SCREEN_MODE_TEXT_1:
+    case VDP_SCREEN_MODE_MULTI_COLOR:
+    case VDP_SCREEN_MODE_GRAPHIC_1:
+    case VDP_SCREEN_MODE_GRAPHIC_2:
+    case VDP_SCREEN_MODE_GRAPHIC_3:
+      r2 = (table >> 10) & 0x7F;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_4:
+    case VDP_SCREEN_MODE_GRAPHIC_5:
+      r2 = ((table >> 10) & 0x7F) | 0x1F;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_6:
+    case VDP_SCREEN_MODE_GRAPHIC_7:
+      r2 = ((table >> 11) & 0x3F) | 0x1F;
+      break;
+    default:
+      return;
   }
-  __critical {
-    RG2SAV = r2;
-    VDP_SET_CONTROL_REGISTER(2, RG2SAV);
-  }
+  __asm__("di");
+  RG2SAV = r2;
+  VDP_SET_CONTROL_REGISTER(2, RG2SAV);
+  __asm__("ei");
 }

--- a/src/vdp_set_palette.c
+++ b/src/vdp_set_palette.c
@@ -17,9 +17,9 @@
 
 void vdp_set_palette(uint8_t idx, const palette_t palette) {
   uint8_t* p = (uint8_t*)&palette;
-  __critical {
-    VDP_SET_CONTROL_REGISTER(16, idx);
-  }
+  __asm__("di");
+  VDP_SET_CONTROL_REGISTER(16, idx);
+  __asm__("ei");
   vdp_port2 = *p++;             /* r, b */
   vdp_port2 = *p++;             /* g */
 }

--- a/src/vdp_set_pattern_table.c
+++ b/src/vdp_set_pattern_table.c
@@ -18,25 +18,25 @@
 void vdp_set_pattern_table(vmemptr_t table) {
   uint8_t r4;
   switch (screen_mode) {
-  case VDP_SCREEN_MODE_TEXT_1:
-  case VDP_SCREEN_MODE_TEXT_2:
-  case VDP_SCREEN_MODE_MULTI_COLOR:
-  case VDP_SCREEN_MODE_GRAPHIC_1:
-    r4 = (table >> 11) & 0x3F;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_2:
-  case VDP_SCREEN_MODE_GRAPHIC_3:
-    r4 = ((table >> 11) & 0x3F) | 0x03;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_4:
-  case VDP_SCREEN_MODE_GRAPHIC_5:
-  case VDP_SCREEN_MODE_GRAPHIC_6:
-  case VDP_SCREEN_MODE_GRAPHIC_7:
-  default:
-    return;
+    case VDP_SCREEN_MODE_TEXT_1:
+    case VDP_SCREEN_MODE_TEXT_2:
+    case VDP_SCREEN_MODE_MULTI_COLOR:
+    case VDP_SCREEN_MODE_GRAPHIC_1:
+      r4 = (table >> 11) & 0x3F;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_2:
+    case VDP_SCREEN_MODE_GRAPHIC_3:
+      r4 = ((table >> 11) & 0x3F) | 0x03;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_4:
+    case VDP_SCREEN_MODE_GRAPHIC_5:
+    case VDP_SCREEN_MODE_GRAPHIC_6:
+    case VDP_SCREEN_MODE_GRAPHIC_7:
+    default:
+      return;
   }
-  __critical {
-    RG4SAV = r4;
-    VDP_SET_CONTROL_REGISTER(4, RG4SAV);
-  }
+  __asm__("di");
+  RG4SAV = r4;
+  VDP_SET_CONTROL_REGISTER(4, RG4SAV);
+  __asm__("ei");
 }

--- a/src/vdp_set_screen_lines.c
+++ b/src/vdp_set_screen_lines.c
@@ -16,8 +16,8 @@
 #include "vdp_internal.h"
 
 void vdp_set_screen_lines(enum vdp_screen_lines lines) {
-  __critical {
-    RG9SAV = (RG9SAV & ~0x80) | lines;
-    VDP_SET_CONTROL_REGISTER(9, RG9SAV);
-  }
+  __asm__("di");
+  RG9SAV = (RG9SAV & ~0x80) | lines;
+  VDP_SET_CONTROL_REGISTER(9, RG9SAV);
+  __asm__("ei");
 }

--- a/src/vdp_set_screen_mode.c
+++ b/src/vdp_set_screen_mode.c
@@ -19,54 +19,54 @@ void vdp_set_screen_mode(enum vdp_screen_mode mode) {
   uint8_t r0;                   /* 0| 0| 0| 0|M5|M4|M3| 0 */
   uint8_t r1;                   /* 0| 0| 0|M1|M2| 0| 0| 0 */
   switch (mode) {
-  case VDP_SCREEN_MODE_TEXT_1:
-    r0 = 0x00; r1 = 0x10;
-    sprite_mode = 0;
-    break;
-  case VDP_SCREEN_MODE_TEXT_2:
-    r0 = 0x08; r1 = 0x10;
-    sprite_mode = 0;
-    break;
-  case VDP_SCREEN_MODE_MULTI_COLOR:
-    r0 = 0x00; r1 = 0x08;
-    sprite_mode = 1;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_1:
-    r0 = 0x00; r1 = 0x00;
-    sprite_mode = 1;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_2:
-    r0 = 0x02; r1 = 0x00;
-    sprite_mode = 1;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_3:
-    r0 = 0x04; r1 = 0x00;
-    sprite_mode = 2;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_4:
-    r0 = 0x06; r1 = 0x00;
-    sprite_mode = 2;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_5:
-    r0 = 0x08; r1 = 0x00;
-    sprite_mode = 2;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_6:
-    r0 = 0x0A; r1 = 0x00;
-    sprite_mode = 2;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_7:
-    r0 = 0x0E; r1 = 0x00;
-    sprite_mode = 2;
-    break;
-  default:
-    return;
+    case VDP_SCREEN_MODE_TEXT_1:
+      r0 = 0x00; r1 = 0x10;
+      sprite_mode = 0;
+      break;
+    case VDP_SCREEN_MODE_TEXT_2:
+      r0 = 0x08; r1 = 0x10;
+      sprite_mode = 0;
+      break;
+    case VDP_SCREEN_MODE_MULTI_COLOR:
+      r0 = 0x00; r1 = 0x08;
+      sprite_mode = 1;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_1:
+      r0 = 0x00; r1 = 0x00;
+      sprite_mode = 1;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_2:
+      r0 = 0x02; r1 = 0x00;
+      sprite_mode = 1;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_3:
+      r0 = 0x04; r1 = 0x00;
+      sprite_mode = 2;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_4:
+      r0 = 0x06; r1 = 0x00;
+      sprite_mode = 2;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_5:
+      r0 = 0x08; r1 = 0x00;
+      sprite_mode = 2;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_6:
+      r0 = 0x0A; r1 = 0x00;
+      sprite_mode = 2;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_7:
+      r0 = 0x0E; r1 = 0x00;
+      sprite_mode = 2;
+      break;
+    default:
+      return;
   }
-  __critical {
-    screen_mode = mode;
-    RG0SAV = (RG0SAV & ~0x0e) | r0;
-    RG1SAV = (RG1SAV & ~0x18) | r1;
-    VDP_SET_CONTROL_REGISTER(0, RG0SAV);
-    VDP_SET_CONTROL_REGISTER(1, RG1SAV);
-  }
+  __asm__("di");
+  screen_mode = mode;
+  RG0SAV = (RG0SAV & ~0x0e) | r0;
+  RG1SAV = (RG1SAV & ~0x18) | r1;
+  VDP_SET_CONTROL_REGISTER(0, RG0SAV);
+  VDP_SET_CONTROL_REGISTER(1, RG1SAV);
+  __asm__("ei");
 }

--- a/src/vdp_set_sprite_attribute_table.c
+++ b/src/vdp_set_sprite_attribute_table.c
@@ -19,32 +19,32 @@ void vdp_set_sprite_attribute_table(vmemptr_t table) {
   uint8_t r5;
   uint8_t r11;
   switch (screen_mode) {
-  case VDP_SCREEN_MODE_TEXT_1:
-  case VDP_SCREEN_MODE_TEXT_2:
-    return;
-  case VDP_SCREEN_MODE_MULTI_COLOR:
-  case VDP_SCREEN_MODE_GRAPHIC_1:
-  case VDP_SCREEN_MODE_GRAPHIC_2:
-    r5 = (table >>  7) & 0xFF;
-    r11 = (table >> 15) & 0x03;
-    break;
-  case VDP_SCREEN_MODE_GRAPHIC_3:
-  case VDP_SCREEN_MODE_GRAPHIC_4:
-  case VDP_SCREEN_MODE_GRAPHIC_5:
-  case VDP_SCREEN_MODE_GRAPHIC_6:
-  case VDP_SCREEN_MODE_GRAPHIC_7:
-    r5 = ((table >> 7) & 0xFF) | 0x07;
-    r11 = (table >> 15) & 0x03;
-    break;
-  default:
-    return;
+    case VDP_SCREEN_MODE_TEXT_1:
+    case VDP_SCREEN_MODE_TEXT_2:
+      return;
+    case VDP_SCREEN_MODE_MULTI_COLOR:
+    case VDP_SCREEN_MODE_GRAPHIC_1:
+    case VDP_SCREEN_MODE_GRAPHIC_2:
+      r5 = (table >>  7) & 0xFF;
+      r11 = (table >> 15) & 0x03;
+      break;
+    case VDP_SCREEN_MODE_GRAPHIC_3:
+    case VDP_SCREEN_MODE_GRAPHIC_4:
+    case VDP_SCREEN_MODE_GRAPHIC_5:
+    case VDP_SCREEN_MODE_GRAPHIC_6:
+    case VDP_SCREEN_MODE_GRAPHIC_7:
+      r5 = ((table >> 7) & 0xFF) | 0x07;
+      r11 = (table >> 15) & 0x03;
+      break;
+    default:
+      return;
   }
-  __critical {
-    RG5SAV = r5;
-    VDP_SET_CONTROL_REGISTER(5, RG5SAV);
-    if (0 < msx_get_version()) {
-      RG11SA = r11;
-      VDP_SET_CONTROL_REGISTER(11, RG11SA);
-    }
+  __asm__("di");
+  RG5SAV = r5;
+  VDP_SET_CONTROL_REGISTER(5, RG5SAV);
+  if (0 < msx_get_version()) {
+    RG11SA = r11;
+    VDP_SET_CONTROL_REGISTER(11, RG11SA);
   }
+  __asm__("ei");
 }

--- a/src/vdp_set_sprite_pattern_table.c
+++ b/src/vdp_set_sprite_pattern_table.c
@@ -18,24 +18,24 @@
 void vdp_set_sprite_pattern_table(vmemptr_t table) {
   uint8_t r6;
   switch (screen_mode) {
-  case VDP_SCREEN_MODE_TEXT_1:
-  case VDP_SCREEN_MODE_TEXT_2:
-    return;
-  case VDP_SCREEN_MODE_MULTI_COLOR:
-  case VDP_SCREEN_MODE_GRAPHIC_1:
-  case VDP_SCREEN_MODE_GRAPHIC_2:
-  case VDP_SCREEN_MODE_GRAPHIC_3:
-  case VDP_SCREEN_MODE_GRAPHIC_4:
-  case VDP_SCREEN_MODE_GRAPHIC_5:
-  case VDP_SCREEN_MODE_GRAPHIC_6:
-  case VDP_SCREEN_MODE_GRAPHIC_7:
-    r6 = (table >> 11) & 0x3F;
-    break;
-  default:
-    return;
+    case VDP_SCREEN_MODE_TEXT_1:
+    case VDP_SCREEN_MODE_TEXT_2:
+      return;
+    case VDP_SCREEN_MODE_MULTI_COLOR:
+    case VDP_SCREEN_MODE_GRAPHIC_1:
+    case VDP_SCREEN_MODE_GRAPHIC_2:
+    case VDP_SCREEN_MODE_GRAPHIC_3:
+    case VDP_SCREEN_MODE_GRAPHIC_4:
+    case VDP_SCREEN_MODE_GRAPHIC_5:
+    case VDP_SCREEN_MODE_GRAPHIC_6:
+    case VDP_SCREEN_MODE_GRAPHIC_7:
+      r6 = (table >> 11) & 0x3F;
+      break;
+    default:
+      return;
   }
-  __critical {
-    RG6SAV = r6;
-    VDP_SET_CONTROL_REGISTER(6, RG6SAV);
-  }
+  __asm__("di");
+  RG6SAV = r6;
+  VDP_SET_CONTROL_REGISTER(6, RG6SAV);
+  __asm__("ei");
 }

--- a/src/vdp_set_sprite_size.c
+++ b/src/vdp_set_sprite_size.c
@@ -16,8 +16,8 @@
 #include "vdp_internal.h"
 
 void vdp_set_sprite_size(enum vdp_sprite_size size) {
-  __critical {
-    RG1SAV = (RG1SAV & ~0x03) | size;
-    VDP_SET_CONTROL_REGISTER(1, RG1SAV);
-  }
+  __asm__("di");
+  RG1SAV = (RG1SAV & ~0x03) | size;
+  VDP_SET_CONTROL_REGISTER(1, RG1SAV);
+  __asm__("ei");
 }

--- a/src/vdp_set_sprite_visible.c
+++ b/src/vdp_set_sprite_visible.c
@@ -16,12 +16,12 @@
 #include "vdp_internal.h"
 
 void vdp_set_sprite_visible(bool visible) {
-  __critical {
-    if (visible) {
-      RG8SAV &= ~0x02;
-    } else {
-      RG8SAV |= 0x02;
-    }
-    VDP_SET_CONTROL_REGISTER(8, RG8SAV);
+  __asm__("di");
+  if (visible) {
+    RG8SAV &= ~0x02;
+  } else {
+    RG8SAV |= 0x02;
   }
+  VDP_SET_CONTROL_REGISTER(8, RG8SAV);
+  __asm__("ei");
 }

--- a/src/vdp_set_visible.c
+++ b/src/vdp_set_visible.c
@@ -16,12 +16,12 @@
 #include "vdp_internal.h"
 
 void vdp_set_visible(bool visible) {
-  __critical {
-    if (visible) {
-      RG1SAV |= 0x40;
-    } else {
-      RG1SAV &= ~0x40;
-    }
-    VDP_SET_CONTROL_REGISTER(1, RG1SAV);
+  __asm__("di");
+  if (visible) {
+    RG1SAV |= 0x40;
+  } else {
+    RG1SAV &= ~0x40;
   }
+  VDP_SET_CONTROL_REGISTER(1, RG1SAV);
+  __asm__("ei");
 }

--- a/src/vdp_set_vscroll.c
+++ b/src/vdp_set_vscroll.c
@@ -16,8 +16,8 @@
 #include "vdp_internal.h"
 
 void vdp_set_vscroll(uint8_t y) {
-  __critical {
-    RG23SA = y;
-    VDP_SET_CONTROL_REGISTER(23, y);
-  }
+  __asm__("di");
+  RG23SA = y;
+  VDP_SET_CONTROL_REGISTER(23, y);
+  __asm__("ei");
 }

--- a/src/vdp_write_control.c
+++ b/src/vdp_write_control.c
@@ -16,10 +16,10 @@
 #include "vdp_internal.h"
 
 void vdp_write_control(uint8_t reg, void* src, uint8_t len) {
-  __critical {
-    VDP_SET_CONTROL_REGISTER_POINTER_AUTO_INCREMENT(reg);
-    for (uint8_t* p = src; len--; ) {
-      VDP_SET_CONTROL_REGISTER_VALUE(*p++);
-    }
+  __asm__("di");
+  VDP_SET_CONTROL_REGISTER_POINTER_AUTO_INCREMENT(reg);
+  for (uint8_t* p = src; len--; ) {
+    VDP_SET_CONTROL_REGISTER_VALUE(*p++);
   }
+  __asm__("ei");
 }

--- a/src/vdp_write_palette.c
+++ b/src/vdp_write_palette.c
@@ -17,9 +17,9 @@
 
 void vdp_write_palette(const palette_t palettes[16]) {
   const uint8_t* p = (const uint8_t*)palettes;
-  __critical {
-    VDP_SET_CONTROL_REGISTER(16, 0);
-  }
+  __asm__("di");
+  VDP_SET_CONTROL_REGISTER(16, 0);
+  __asm__("ei");
   for (uint8_t i = 16; i--; ) {
     vdp_port2 = *p++;  /* R, B */
     vdp_port2 = *p++;  /* G */

--- a/src/vmem_memset.c
+++ b/src/vmem_memset.c
@@ -15,19 +15,8 @@
 
 #include "vdp_internal.h"
 
-// void vmem_memset(vmemptr_t dst, uint8_t val, uint16_t len) {
-//   __critical {
-//     vmem_set_write_address(dst);
-//     for (; len--; ) {
-//       vdp_port0 = val;
-//     }
-//   }
-// }
-
 void vmem_memset(vmemptr_t dst, uint8_t val, uint16_t len) {
-  __critical {
-    VDP_SET_VMEM_WRITE_POINTER(dst);
-  }
+  vmem_set_write_address(dst);
   for (; len--; ) {
     VDP_SET_VMEM_VALUE(val);
   }

--- a/src/vmem_read.c
+++ b/src/vmem_read.c
@@ -15,19 +15,8 @@
 
 #include "vdp_internal.h"
 
-// void vmem_read(vmemptr_t src, void* dst, uint16_t len) {
-//   __critical {
-//     vmem_set_read_address(src);
-//     for (uint8_t* p = dst; len--; ) {
-//       *p++ = vdp_port0;
-//     }
-//   }
-// }
-
 void vmem_read(vmemptr_t src, void* dst, uint16_t len) {
-  __critical {
-    VDP_SET_VMEM_READ_POINTER(src);
-  }
+  vmem_set_read_address(src);
   for (uint8_t* p = dst; len--; ) {
     *p++ = VDP_GET_VMEM_VALUE();
   }

--- a/src/vmem_set_read_address.c
+++ b/src/vmem_set_read_address.c
@@ -15,14 +15,8 @@
 
 #include "vdp_internal.h"
 
-// void vmem_set_read_address(vmemptr_t loc) {
-//   VDP_SET_CONTROL_REGISTER(14, (uint8_t)(((loc) >> 14) & 7));
-//   vdp_port1 = (uint8_t)((loc) & 255);
-//   vdp_port1 = (uint8_t)(((loc) >> 8) & 0x3F);
-// }
-
 void vmem_set_read_address(vmemptr_t loc) {
-  __critical {
-    VDP_SET_VMEM_READ_POINTER(loc);
-  }
+  __asm__("di");
+  VDP_SET_VMEM_READ_POINTER(loc);
+  __asm__("ei");
 }

--- a/src/vmem_set_sprite_color_s.c
+++ b/src/vmem_set_sprite_color_s.c
@@ -20,10 +20,8 @@ void vmem_set_sprite_color_s(vmemptr_t base, uint8_t plane,
   const int m = vdp_get_sprite_mode();
   if (!m) return;
   if (m == 1) {
-    __critical {
-      vmem_set_write_address(base + plane * sizeof(struct sprite) + 3);
-      vmem_set(tagged_color);
-    }
+    vmem_set_write_address(base + plane * sizeof(struct sprite) + 3);
+    vmem_set(tagged_color);
     return;
   }
   vmem_memset(base - 0x0200 + plane * sizeof(struct sprite_color),

--- a/src/vmem_set_write_address.c
+++ b/src/vmem_set_write_address.c
@@ -15,14 +15,8 @@
 
 #include "vdp_internal.h"
 
-// void vmem_set_write_address(vmemptr_t loc) {
-//   VDP_SET_CONTROL_REGISTER(14, (uint8_t)(((loc) >> 14) & 7));
-//   vdp_port1 = (uint8_t)((loc) & 255);
-//   vdp_port1 = (uint8_t)(((loc) >> 8) & 0x3F | 0x40);
-// }
-
 void vmem_set_write_address(vmemptr_t loc) {
-  __critical {
-    VDP_SET_VMEM_WRITE_POINTER(loc);
-  }
+  __asm__("di");
+  VDP_SET_VMEM_WRITE_POINTER(loc);
+  __asm__("ei");
 }

--- a/src/vmem_write.c
+++ b/src/vmem_write.c
@@ -15,19 +15,8 @@
 
 #include "vdp_internal.h"
 
-// void vmem_write(vmemptr_t dst, void* src, uint16_t len) {
-//   __critical {
-//     vmem_set_write_address(dst);
-//     for (uint8_t* p = src; len--; ) {
-//       vdp_port0 = *p++;
-//     }
-//   }
-// }
-
 void vmem_write(vmemptr_t dst, void* src, uint16_t len) {
-  __critical {
-    VDP_SET_VMEM_WRITE_POINTER(dst);
-  }
+  vmem_set_write_address(dst);
   for (uint8_t* p = src; len--; ) {
     VDP_SET_VMEM_VALUE(*p++);
   }


### PR DESCRIPTION
The `__critical` block in SDCC is useful for implementing critical sections. It saves the enabled/disabled state of the interrupts before executing the code in the block, and restores that state after the code is executed.

However, on the Z80, this may not work as expected because the `LD A,I` instruction is buggy. (i.e. Interrupts may be disabled after the `__critical` block even if it had been enabled before.)

Therefore, we decided to use the pair `__asm__("di")` and `__asm__("ei")` instead, or remove `__critical`.