### PR TITLE
Feature/crt0 system extension support

### DIFF
--- a/crt0/16k.4000/crt0.s
+++ b/crt0/16k.4000/crt0.s
@@ -1,7 +1,5 @@
 ;;; -*- mode: asm; coding: utf-8-unix; tab-width: 8 -*-
 
-;;; \file crt0/16k.4000/crt0.s
-;;;
 ;;; Copyright (c) 2021 Daishi Mori (mori0091)
 ;;;
 ;;; This software is released under the MIT License.
@@ -10,6 +8,8 @@
 ;;; GitHub libmsx project
 ;;; https://github.com/mori0091/libmsx
 
+;;; \file crt0/16k.4000/crt0.s
+;;;
 ;;; crt0 for MSX ROM of 16KB starting at 0x4000
 ;;; suggested options: --code-loc 0x4010 --data-loc 0xc000
 ;;; `main` should be `void main(void)`
@@ -19,8 +19,6 @@
         .globl  _main
         .globl  _exit
         .globl  _libmsx___init_intr
-
-        HIMEM  = 0xfc4a
 
         .area   _HEADER (ABS)
         ;; ROM header
@@ -41,16 +39,19 @@
         .area   _CODE
         .area   _INITIALIZER
         .area   _GSINIT
-	.area   _GSFINAL
-	.area	_DATA
-	.area	_INITIALIZED
-	.area	_BSEG
-	.area   _BSS
-	.area   _HEAP
+        .area   _GSFINAL
+        .area   _DATA
+        .area   _INITIALIZED
+        .area   _BSEG
+        .area   _BSS
+        .area   _HEAP
         ;; ----
 
-	.area   _CODE
+        .area   _CODE
 init:
+boot:
+start:
+        HIMEM  = 0xfc4a
         ld      sp,(HIMEM)
         call    gsinit
         call    _libmsx___init_intr

--- a/crt0/16k.4000/crt0x.s
+++ b/crt0/16k.4000/crt0x.s
@@ -1,0 +1,79 @@
+;;; -*- mode: asm; coding: utf-8-unix; tab-width: 8 -*-
+
+;;; Copyright (c) 2021 Daishi Mori (mori0091)
+;;;
+;;; This software is released under the MIT License.
+;;; See https://github.com/mori0091/libmsx/blob/main/LICENSE
+;;;
+;;; GitHub libmsx project
+;;; https://github.com/mori0091/libmsx
+
+;;; \file crt0/16k.4000/crt0x.s
+;;;
+;;; crt0 for MSX ROM of 16KB starting at 0x4000
+;;; suggested options: --code-loc 0x4010 --data-loc 0xc000
+;;; `main` should be `void main(void)`
+;;; `return` from `main` causes soft reset.
+;;;
+;;; `main` starts after ALL cartridges are ready.
+;;; Thus, for example, BDOS is available if FDD exists.
+
+        .module crt0x
+        .globl  _main
+        .globl  _exit
+        .globl  _libmsx___init_intr
+
+        .area   _HEADER (ABS)
+        ;; ROM header
+        .org    0x4000
+
+        .db     0x41
+        .db     0x42
+        .dw     init
+        .dw     0x0000
+        .dw     0x0000
+        .dw     0x0000
+        .dw     0x0000
+        .dw     0x0000
+        .dw     0x0000
+
+        ;; ---- ordering segments for linker
+        .area   _HOME
+        .area   _CODE
+        .area   _INITIALIZER
+        .area   _GSINIT
+        .area   _GSFINAL
+        .area   _DATA
+        .area   _INITIALIZED
+        .area   _BSEG
+        .area   _BSS
+        .area   _HEAP
+        ;; ----
+
+        .area   _CODE
+init:
+        H_STKE = 0xfeda
+        ld      hl, #boot
+        ld      de, #H_STKE
+        ld      bc, #5
+        ldir
+        call    get_slot_page1
+        ld      (H_STKE+1), a
+        ret
+boot:   ;; template for H.STKE hook
+        rst     0x30
+        .db     1
+        .dw     start
+        ret
+start:
+        HIMEM  = 0xfc4a
+        ld      sp,(HIMEM)
+        call    gsinit
+        call    _libmsx___init_intr
+        call    _main
+_exit::
+        rst     0x00
+
+;------------------------------------------------
+        .include        "../../crtlib/get_slot_page1.s"
+        .include        "../../sdcc/device/lib/z80/gsinit.s"

--- a/crt0/32k.4000/crt0.s
+++ b/crt0/32k.4000/crt0.s
@@ -1,7 +1,5 @@
 ;;; -*- mode: asm; coding: utf-8-unix; tab-width: 8 -*-
 
-;;; \file crt0/32k.4000/crt0.s
-;;;
 ;;; Copyright (c) 2021 Daishi Mori (mori0091)
 ;;;
 ;;; This software is released under the MIT License.
@@ -10,6 +8,8 @@
 ;;; GitHub libmsx project
 ;;; https://github.com/mori0091/libmsx
 
+;;; \file crt0/32k.4000/crt0.s
+;;;
 ;;; crt0 for MSX ROM of 32KB starting at 0x4000
 ;;; suggested options: --code-loc 0x4010 --data-loc 0xc000
 ;;; `main` should be `void main(void)`
@@ -19,13 +19,6 @@
         .globl  _main
         .globl  _exit
         .globl  _libmsx___init_intr
-
-        RSLREG = 0x0138         ; Read SLot selector REGister
-        ENASLT = 0x0024         ; ENAble SLoT
-
-        EXPTBL = 0xfcc1         ; (4 bytes) Extended flag table of 4 primary slots
-        SLTTBL = 0xfcc5         ; (4 bytes) Save area for secondary slot selector registers
-        HIMEM  = 0xfc4a         ; (2 bytes) Pointer to upper limit address of free area
 
         .area   _HEADER (ABS)
         ;; ROM header
@@ -56,69 +49,19 @@
 
         .area   _CODE
 init:
+boot:
+start:
+        HIMEM  = 0xfc4a         ; (2 bytes) Pointer to upper limit address of free area
         ld      sp, (HIMEM)
-        call    find_rom_page_2
+        call    get_slot_page1
+        call    set_slot_page2
         call    gsinit
         call    _libmsx___init_intr
         call    _main
 _exit::
         rst     0x00
 
-        ;;
 ;------------------------------------------------
-; find_rom_page_2
-; original name     : LOCALIZAR_SEGUNDA_PAGINA
-; Original author   : Eduardo Robsy Petrus
-; Snippet taken from: http://karoshi.auic.es/index.php?topic=117.msg1465
-;
-; Rutina que localiza la segunda pagina de 16 KB
-; de una ROM de 32 KB ubicada en 4000h
-; Basada en la rutina de Konami-
-; Compatible con carga en RAM
-; Compatible con expansores de slots
-;------------------------------------------------
-; Comprobacion de RAM/ROM
-
-find_rom_page_2::
-        ld      hl, #0x4000
-        ld      b, (hl)
-        xor     a
-        ld      (hl), a
-        ld      a, (hl)
-        or      a
-        jr      nz,5$ ; jr nz,@@ROM
-        ; El programa esta en RAM - no buscar
-        ld      (hl), b
-        ret
-5$: ; ----------- @@ROM:
-        di
-        ; Slot primario
-        call    RSLREG
-        rrca
-        rrca
-        and     #0x03
-        ; Slot secundario
-        ld      c, a
-        ld      hl, #EXPTBL
-        add     a, l
-        ld      l, a
-        ld      a, (hl)
-        and     #0x80
-        or      c
-        ld      c, a
-        inc     l
-        inc     l
-        inc     l
-        inc     l
-        ld      a, (hl)
-        ; Definir el identificador de slot
-        and     #0x0c
-        or      c
-        ld      h, #0x80
-        ; Habilitar permanentemente
-        call    ENASLT
-        ei
-        ret
-
-;------------------------------------------------
+        .include        "../../crtlib/get_slot_page1.s"
+        .include        "../../crtlib/set_slot_page2.s"
         .include        "../../sdcc/device/lib/z80/gsinit.s"

--- a/crt0/32k.4000/crt0x.s
+++ b/crt0/32k.4000/crt0x.s
@@ -1,0 +1,82 @@
+;;; -*- mode: asm; coding: utf-8-unix; tab-width: 8 -*-
+
+;;; Copyright (c) 2021 Daishi Mori (mori0091)
+;;;
+;;; This software is released under the MIT License.
+;;; See https://github.com/mori0091/libmsx/blob/main/LICENSE
+;;;
+;;; GitHub libmsx project
+;;; https://github.com/mori0091/libmsx
+
+;;; \file crt0/32k.4000/crt0x.s
+;;;
+;;; crt0 for MSX ROM of 32KB starting at 0x4000
+;;; suggested options: --code-loc 0x4010 --data-loc 0xc000
+;;; `main` should be `void main(void)`
+;;; `return` from `main` causes soft reset.
+;;;
+;;; `main` starts after ALL cartridges are ready.
+;;; Thus, for example, BDOS is available if FDD exists.
+
+        .module crt0x
+        .globl  _main
+        .globl  _exit
+        .globl  _libmsx___init_intr
+
+        .area   _HEADER (ABS)
+        ;; ROM header
+        .org    0x4000
+
+        .db     0x41
+        .db     0x42
+        .dw     init
+        .dw     0x0000
+        .dw     0x0000
+        .dw     0x0000
+        .dw     0x0000
+        .dw     0x0000
+        .dw     0x0000
+
+        ;; ---- ordering segments for linker
+        .area   _HOME
+        .area   _CODE
+        .area   _INITIALIZER
+        .area   _GSINIT
+        .area   _GSFINAL
+        .area   _DATA
+        .area   _INITIALIZED
+        .area   _BSEG
+        .area   _BSS
+        .area   _HEAP
+        ;; ----
+
+        .area   _CODE
+init:
+        H_STKE = 0xfeda
+        ld      hl, #boot
+        ld      de, #H_STKE
+        ld      bc, #5
+        ldir
+        call    get_slot_page1
+        ld      (H_STKE+1), a
+        ret
+boot:   ;; template for H.STKE hook
+        rst     0x30
+        .db     1
+        .dw     start
+        ret
+start:
+        HIMEM  = 0xfc4a         ; (2 bytes) Pointer to upper limit address of free area
+        ld      sp, (HIMEM)
+        call    get_slot_page1
+        call    set_slot_page2
+        call    gsinit
+        call    _libmsx___init_intr
+        call    _main
+_exit::
+        rst     0x00
+
+;------------------------------------------------
+        .include        "../../crtlib/get_slot_page1.s"
+        .include        "../../crtlib/set_slot_page2.s"
+        .include        "../../sdcc/device/lib/z80/gsinit.s"

--- a/crt0/rom_mapper/crt0x.s
+++ b/crt0/rom_mapper/crt0x.s
@@ -1,0 +1,101 @@
+;;; -*- mode: asm; coding: utf-8-unix; tab-width: 8 -*-
+
+;;; Copyright (c) 2022 Daishi Mori (mori0091)
+;;;
+;;; This software is released under the MIT License.
+;;; See https://github.com/mori0091/libmsx/blob/main/LICENSE
+;;;
+;;; GitHub libmsx project
+;;; https://github.com/mori0091/libmsx
+
+;;; \file crt0/rom_mapper/crt0.s
+;;; C startup routine for MSX w/ ROM mapper and SDCC banked call support.
+;;;
+;;; crt0 for MSX ROM of 32KB starting at 0x4000
+;;; suggested options: --code-loc 0x4010 --data-loc 0xc000
+;;; `main` should be `void main(void)`
+;;; `return` from `main` causes soft reset.
+;;;
+;;; `main` starts after ALL cartridges are ready.
+;;; Thus, for example, BDOS is available if FDD exists.
+;;;
+;;; \note
+;;; It is a common part of crt0 and is intended to be used with one of a ROM
+;;; mapper-specific modules such as rom_ascii8.s and rom_ascii16.s.
+
+        .module crt0x
+
+        .globl  _main
+        .globl  _exit
+        .globl  _libmsx___init_intr
+        .globl rom_init
+        .globl set_bank
+
+        .area   _HEADER (ABS)
+        ;; ROM header
+        .org    0x4000
+
+        .db     0x41
+        .db     0x42
+        .dw     init
+        .dw     0x0000
+        .dw     0x0000
+        .dw     0x0000
+        .dw     0x0000
+        .dw     0x0000
+        .dw     0x0000
+
+        ;; ---- ordering segments for linker
+        .area   _HOME
+        .area   _CODE
+        .area   _INITIALIZER
+        .area   _GSINIT
+        .area   _GSFINAL
+        ;; ----
+        .area   _BANK0
+        ;; ----
+        .area   _DATA
+        .area   _INITIALIZED
+        .area   _BSEG
+        .area   _BSS
+        .area   _HEAP
+        ;; ----
+        .area   _BANK1
+        .area   _BANK2
+        .area   _BANK3
+        .area   _BANK4
+        .area   _BANK5
+        .area   _BANK6
+        ;; ----
+
+        .area   _CODE
+init:
+        H_STKE = 0xfeda
+        ld      hl, #boot
+        ld      de, #H_STKE
+        ld      bc, #5
+        ldir
+        call    get_slot_page1
+        ld      (H_STKE+1), a
+        ret
+boot:   ;; template for H.STKE hook
+        rst     0x30
+        .db     1
+        .dw     start
+        ret
+start:
+        HIMEM  = 0xfc4a         ; (2 bytes) Pointer to upper limit address of free area
+        ld      sp,(HIMEM)
+        call    get_slot_page1
+        call    set_slot_page2
+        call    rom_init        ; select ROM banks
+        call    gsinit          ; initialize RAM
+        call    _libmsx___init_intr ; install interrupt routine
+        call    _main
+_exit::
+        rst     0x00
+
+;------------------------------------------------
+        .include        "../../crtlib/get_slot_page1.s"
+        .include        "../../crtlib/set_slot_page2.s"
+        .include        "../../sdcc/device/lib/z80/gsinit.s"

--- a/crtlib/get_slot_page1.s
+++ b/crtlib/get_slot_page1.s
@@ -1,0 +1,49 @@
+;;; -*- mode: asm; coding: utf-8-unix; tab-width: 8 -*-
+
+;;; Copyright (c) 2022 Daishi Mori (mori0091)
+;;;
+;;; This software is released under the MIT License.
+;;; See https://github.com/mori0091/libmsx/blob/main/LICENSE
+;;;
+;;; GitHub libmsx project
+;;; https://github.com/mori0091/libmsx
+
+;;; \file crtlib/get_slot_page1.s
+
+        .module get_slot_page1
+
+;; \brief Get slot address of page #1.
+;;
+;; \retval A  slot
+;; \post Interrupts are enabled.
+        .area   _CODE
+get_slot_page1::
+        RSLREG = 0x0138         ; Read SLot selector REGister
+        EXPTBL = 0xfcc1         ; (4 bytes) Extended flag table of 4 primary slots
+        SLTTBL = 0xfcc5         ; (4 bytes) Save area for secondary slot selector registers
+        di
+        ; A = Primary slot of page #1
+        call    RSLREG
+        rrca
+        rrca
+        and     #0x03
+        ; A |= Extended flag of the primary slot
+        ld      c, a
+        ld      hl, #EXPTBL
+        add     a, l
+        ld      l, a
+        ld      a, (hl)
+        and     #0x80
+        or      c
+        ; A |= Secondary slot of page #1
+        ld      c, a
+        inc     l
+        inc     l
+        inc     l
+        inc     l
+        ld      a, (hl)
+        and     #0x0c
+        or      c
+        ; return the slot address
+        ei
+        ret

--- a/crtlib/set_slot_page2.s
+++ b/crtlib/set_slot_page2.s
@@ -1,0 +1,25 @@
+;;; -*- mode: asm; coding: utf-8-unix; tab-width: 8 -*-
+
+;;; Copyright (c) 2022 Daishi Mori (mori0091)
+;;;
+;;; This software is released under the MIT License.
+;;; See https://github.com/mori0091/libmsx/blob/main/LICENSE
+;;;
+;;; GitHub libmsx project
+;;; https://github.com/mori0091/libmsx
+
+;;; \file crtlib/set_slot_page2.s
+
+        .module set_slot_page2
+
+;; \brief Switch slot of page #2 to the given slot.
+;;
+;; \param A  slot
+;; \post Interrupts are enabled.
+        .area   _CODE
+set_slot_page2::
+        ENASLT = 0x0024         ; ENAble SLoT
+        ld      h, #0x80
+        call    ENASLT
+        ei
+        ret

--- a/include/workarea.h
+++ b/include/workarea.h
@@ -133,4 +133,71 @@ static volatile __at (0xfcc9) uint8_t SLTATR[64];
  */
 static volatile __at (0xfd09) uint8_t SLTWRK[128];
 
+// ---- FDC workarea ----
+
+/**
+ * Slot address of page #0 of RAM.
+ *
+ * \note
+ * Available only if a Floppy Disk Controller (FDC) exists and was initialized
+ * at system startup.
+ */
+static volatile __at (0xf341) uint8_t RAMAD0;
+
+/**
+ * Slot address of page #1 of RAM.
+ *
+ * \note
+ * Available only if a Floppy Disk Controller (FDC) exists and was initialized
+ * at system startup.
+ */
+static volatile __at (0xf342) uint8_t RAMAD1;
+
+/**
+ * Slot address of page #2 of RAM.
+ *
+ * \note
+ * Available only if a Floppy Disk Controller (FDC) exists and was initialized
+ * at system startup.
+ */
+static volatile __at (0xf343) uint8_t RAMAD2;
+
+/**
+ * Slot address of page #3 of RAM.
+ *
+ * \note
+ * Available only if a Floppy Disk Controller (FDC) exists and was initialized
+ * at system startup.
+ */
+static volatile __at (0xf344) uint8_t RAMAD3;
+
+/**
+ * Slot address of the master FDC cartridge.
+ *
+ * \note
+ * Available only if a Floppy Disk Controller (FDC) exists and was initialized
+ * at system startup.
+ */
+static volatile __at (0xf348) uint8_t MASTERS;
+
+/**
+ * Slot and number of drives for each Floppy Disk Controller (FDC).
+ *
+ * | DRVTBL[*] | explanation                     |
+ * | --------- | ------------------------------- |
+ * | DRVTBL[0] | Number of drives of the 1st FDC |
+ * | DRVTBL[1] | Slot address of the 1st FDC     |
+ * | DRVTBL[2] | Number of drives of the 2nd FDC |
+ * | DRVTBL[3] | Slot address of the 2nd FDC     |
+ * | DRVTBL[4] | Number of drives of the 3rd FDC |
+ * | DRVTBL[5] | Slot address of the 3rd FDC     |
+ * | DRVTBL[6] | Number of drives of the 4th FDC |
+ * | DRVTBL[7] | Slot address of the 4th FDC     |
+ *
+ * \note
+ * Available only if a Floppy Disk Controller (FDC) exists and was initialized
+ * at system startup.
+ */
+static volatile __at (0xfb21) uint8_t DRVTBL[8];
+
 #endif

--- a/mk/16k.4000.mk
+++ b/mk/16k.4000.mk
@@ -19,4 +19,8 @@ ADDR_DATA = 0xc000
 
 IHX2BIN_FLAGS = -s ${IMAGE_SIZE} -b ${ADDR_HEAD}
 
+ifeq (${USE_ALL_EXTENSIONS}, 1)
+CRT0 = ${LIBMSX_HOME}/lib/16k.4000/crt0x.rel
+else
 CRT0 = ${LIBMSX_HOME}/lib/16k.4000/crt0.rel
+endif

--- a/mk/32k.4000.mk
+++ b/mk/32k.4000.mk
@@ -19,4 +19,8 @@ ADDR_DATA = 0xc000
 
 IHX2BIN_FLAGS = -s ${IMAGE_SIZE} -b ${ADDR_HEAD}
 
+ifeq (${USE_ALL_EXTENSIONS}, 1)
+CRT0 = ${LIBMSX_HOME}/lib/32k.4000/crt0x.rel
+else
 CRT0 = ${LIBMSX_HOME}/lib/32k.4000/crt0.rel
+endif

--- a/mk/Makefile
+++ b/mk/Makefile
@@ -50,6 +50,14 @@ LIBS    =
 # (default is 'bin', if omitted)
 # BINDIR = bin
 
+# [OPTIONAL]
+# If `USE_ALL_EXTENSIONS` is set to `1`, all connected system extensions (e.g.
+# disk drive, RS-232C cartridge) are initialized and ready for use before your
+# `main()` function starts. Maybe some RAM space and startup time are consumed
+# though.
+# (default is undefined, if omitted)
+# USE_ALL_EXTENSIONS =
+
 # [REQUIRED]
 # Include one of the configuration.
 #   - ${LIBMSX_HOME}/mk/16k.4000.mk : to make 16KB rom image (0x4000-0x7fff)

--- a/mk/ascii16.mk
+++ b/mk/ascii16.mk
@@ -58,5 +58,9 @@ IHX2BIN_FLAGS = -s ${IMAGE_SIZE} -b ${ADDR_HEAD} \
 		-b 0x68000			 \
 		--pow2
 
+ifeq (${USE_ALL_EXTENSIONS}, 1)
+CRT0 = ${LIBMSX_HOME}/lib/rom_mapper/crt0x.rel
+else
 CRT0 = ${LIBMSX_HOME}/lib/rom_mapper/crt0.rel
+endif
 CRT0 += ${LIBMSX_HOME}/lib/rom_mapper/rom_ascii16.rel

--- a/mk/ascii8.mk
+++ b/mk/ascii8.mk
@@ -58,5 +58,9 @@ IHX2BIN_FLAGS = -s ${IMAGE_SIZE} -b ${ADDR_HEAD} \
 		-b 0x68000			 \
 		--pow2
 
+ifeq (${USE_ALL_EXTENSIONS}, 1)
+CRT0 = ${LIBMSX_HOME}/lib/rom_mapper/crt0x.rel
+else
 CRT0 = ${LIBMSX_HOME}/lib/rom_mapper/crt0.rel
+endif
 CRT0 += ${LIBMSX_HOME}/lib/rom_mapper/rom_ascii8.rel

--- a/sample/check_slots/Makefile
+++ b/sample/check_slots/Makefile
@@ -51,10 +51,20 @@ LIBS    =
 # (default is 'bin', if omitted)
 # BINDIR = bin
 
+# [OPTIONAL]
+# If `USE_ALL_EXTENSIONS` is set to `1`, all connected system extensions (e.g.
+# disk drive, RS-232C cartridge) are initialized and ready for use before your
+# `main()` function starts. Maybe some RAM space and startup time are consumed
+# though.
+# (default is undefined, if omitted)
+USE_ALL_EXTENSIONS = 1
+
 # [REQUIRED]
 # Include one of the configuration.
 #   - ${LIBMSX_HOME}/mk/16k.4000.mk : to make 16KB rom image (0x4000-0x7fff)
 #   - ${LIBMSX_HOME}/mk/32k.4000.mk : to make 32KB rom image (0x4000-0xbfff)
+#   - ${LIBMSX_HOME}/mk/ascii16.mk  : to make MegaROM image (ROM type: ASCII16)
+#   - ${LIBMSX_HOME}/mk/ascii8.mk   : to make MegaROM image (ROM type: ASCII8)
 include ${LIBMSX_HOME}/mk/16k.4000.mk
 
 # [REQUIRED] (No need to modify)

--- a/sample/check_slots/src/check_slots.c
+++ b/sample/check_slots/src/check_slots.c
@@ -155,11 +155,24 @@ void main(void) {
   puts(" MAIN ROM  : "); print_slot(EXPTBL[0]); putc('\n');
   if (0 < msx_get_version()) {
     // MSX2 or later
-    puts(" SUB ROM   : "); print_slot(EXBRSA);    putc('\n');
+    puts(" SUB ROM   : "); print_slot(EXBRSA); putc('\n');
   }
   putc('\n');
   if (find_OPLL()) {
     list_OPLL();
+  }
+  putc('\n');
+  if (DRVTBL[0]) {
+    puts("FDC        : slot"); putc('\n');
+    const volatile uint8_t * p = DRVTBL;
+    while (*p) {
+      puts("   "); puti(p[0]); puts(" drives: "); print_slot(p[1]);
+      if (p[1] == MASTERS) {
+        puts(" (master slot)");
+      }
+      putc('\n');
+      p += 2;
+    }
   }
 
   for (;;) {


### PR DESCRIPTION
To support system extension (such as FDC), added new C startup routine `crt0x` for each ROM type. New `crt0x` is used if `USE_ALL_EXTENSIONS` make variable was set to `1`.