### PR TITLE
Fix/BIOS calling convention issue

### DIFF
--- a/include/bios.h
+++ b/include/bios.h
@@ -21,6 +21,10 @@
 #include "bios_const.h"
 #include "bios_entry.h"
 
+#ifndef __SDCCCALL
+#define __sdcccall(x)
+#endif
+
 /**
  * Returns MSX system version code.
  *
@@ -64,7 +68,8 @@ uint8_t msx_RDSLT(uint8_t slot, void * addr);
  *
  * \post Interrupt is disabled.
  */
-void msx_WRSLT(uint8_t slot, void * addr, uint8_t value);
+void msx_WRSLT(uint8_t slot, void * addr, uint8_t value) __sdcccall(0);
+
 
 /**
  * BIOS : ENASLT (0024H / MAIN) `MSX`.
@@ -247,5 +252,9 @@ uint8_t msx_GETCPU(void);
  * \sa msx_GETCPU()
  */
 uint8_t msx_get_cpu_mode(void);
+
+#ifndef __SDCCCALL
+#undef __sdcccall
+#endif
 
 #endif

--- a/include/bios_entry.h
+++ b/include/bios_entry.h
@@ -32,7 +32,7 @@
  *
  * \retval A value of the address of the slot.
  *
- * \post AF, BC, DE registers will be changed.
+ * \post AF, BC, DE registers are changed.
  * \post Interrupt is disabled.
  *
  * \sa msx_RDSLT()

--- a/sample/check_slots/src/bdos.c
+++ b/sample/check_slots/src/bdos.c
@@ -1,0 +1,65 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file bdos.c
+ */
+
+#include <config.h>
+#include "bdos.h"
+
+#ifndef __SDCCCALL
+#define __sdcccall(x)
+#endif
+
+void bdos(uint8_t c, struct z80_reg * reg) __sdcccall(0) __naked {
+  (void)c;                      // (sp+2)  --> C
+  (void)reg;                    // (sp+3) --> IX
+  __asm__("push af");
+  __asm__("push bc");
+  __asm__("push de");
+  __asm__("push hl");
+  __asm__("push ix");
+  __asm__("push iy");
+
+  __asm__("ld ix, #12");
+  __asm__("add ix, sp");
+  __asm__("ld c, 2 (ix)");
+  __asm__("ld e, 3 (ix)");
+  __asm__("ld d, 4 (ix)");
+  __asm__("push de");
+  __asm__("pop ix");
+
+  __asm__("ld a, 1 (ix)");
+  __asm__("ld b, 3 (ix)");
+  __asm__("ld e, 4 (ix)");
+  __asm__("ld d, 5 (ix)");
+  __asm__("ld l, 6 (ix)");
+  __asm__("ld h, 7 (ix)");
+  __asm__("push ix");
+  __asm__("call 0xf37d");
+  __asm__("pop ix");
+  __asm__("ld 1 (ix), a");
+  __asm__("ld 2 (ix), c");
+  __asm__("ld 3 (ix), b");
+  __asm__("ld 4 (ix), e");
+  __asm__("ld 5 (ix), d");
+  __asm__("ld 6 (ix), l");
+  __asm__("ld 7 (ix), h");
+
+  __asm__("pop iy");
+  __asm__("pop ix");
+  __asm__("pop hl");
+  __asm__("pop de");
+  __asm__("pop bc");
+  __asm__("pop af");
+
+  __asm__("ret");
+}

--- a/sample/check_slots/src/bdos.h
+++ b/sample/check_slots/src/bdos.h
@@ -1,0 +1,43 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file bdos.h
+ */
+
+#pragma once
+
+#ifndef BDOS_H_
+#define BDOS_H_
+
+#include <stdint.h>
+
+struct z80_reg {
+  uint16_t af;
+  uint16_t bc;
+  uint16_t de;
+  uint16_t hl;
+};
+
+#ifndef __SDCCCALL
+#define __sdcccall(x)
+#endif
+
+/**
+ * Wrapper for BDOS call.
+ * \param reg [inout]  pointer to value of CPU registers.
+ */
+void bdos(uint8_t c, struct z80_reg * reg) __sdcccall(0);
+
+#ifndef __SDCCCALL
+#undef __sdcccall
+#endif
+
+#endif // BDOS_H_

--- a/sample/check_slots/src/check_slots.c
+++ b/sample/check_slots/src/check_slots.c
@@ -19,6 +19,16 @@
 #include <stdint.h>
 
 #include "screen1.h"
+#include "scc.h"
+#include "bdos.h"
+
+/**
+ * Clear screen.
+ */
+void cls(void) {
+  clear_vmem();
+  locate(0, 0);
+}
 
 /**
  * Print the slot address.
@@ -26,13 +36,13 @@
  * \param slot  the slot address
  */
 void print_slot(uint8_t slot) {
+  puti(slot & 3);
   if (slot & 0x80) {
-    puti(slot & 3);
     putc('-');
     puti((slot >> 2) & 3);
   }
   else {
-    puti(slot & 3);
+    puts("  ");
   }
 }
 
@@ -83,14 +93,84 @@ int slot_bcmp(uint8_t slot, const void * addr, const void * s, size_t len) {
 
 // -----------------------------------------------------------------------
 
+bool is_MAIN_ROM(uint8_t slot) {
+  return (slot == EXPTBL[0]);
+}
+
+bool is_SUB_ROM(uint8_t slot) {
+  return (EXBRSA && slot == EXBRSA || !slot_bcmp(slot, (const void *)0x0000, "CD", 2));
+}
+
+bool is_RAM(uint8_t slot) {
+  return (slot == msx_get_slot((void *)0xc000));
+}
+
+bool is_internal_OPLL(uint8_t slot) {
+  return (!slot_bcmp(slot, (const void *)0x4018, "APRLOPLL", 8));
+}
+
+bool is_FMPAC(uint8_t slot) {
+  return (!slot_bcmp(slot, (const void *)0x4018, "PAC2OPLL", 8));
+}
+
+bool is_OPLL(uint8_t slot) {
+  return (!slot_bcmp(slot, (const void *)0x401c, "OPLL", 4));
+}
+
+bool is_SCC(uint8_t slot) {
+  return (0 < SCC_inspect(slot));
+}
+
+bool is_SCCPlus(uint8_t slot) {
+  return (1 < SCC_inspect(slot));
+}
+
+bool is_BDOS(uint8_t slot) {
+  if (!DRVTBL[0]) return false;
+  const volatile uint8_t * p = DRVTBL;
+  while (*p) {
+    if (slot == p[1]) {
+      return true;
+    }
+    p += 2;
+  }
+  return false;
+}
+
+bool is_ROM_p1(uint8_t slot) {
+  return (!slot_bcmp(slot, (const void *)0x4000, "AB", 2));
+}
+
+bool is_ROM_p2(uint8_t slot) {
+  return (!slot_bcmp(slot, (const void *)0x8000, "AB", 2));
+}
+
+bool is_ROM(uint8_t slot) {
+  return (is_ROM_p1(slot) || is_ROM_p2(slot));
+}
+
+bool is_read_only(uint8_t slot, void * addr) {
+  const uint8_t x = msx_RDSLT(slot, addr);
+  msx_WRSLT(slot, addr, ~x);
+  if (!(x ^ msx_RDSLT(slot, addr))) {
+    __asm__("ei");
+    return true;
+  }
+  msx_WRSLT(slot, addr, x);
+  __asm__("ei");
+  return false;
+}
+
+// -----------------------------------------------------------------------
+
 static void find_internal_OPLL_callback(uint8_t slot, void * arg) {
-  if (!slot_bcmp(slot, (const void *)0x4018, "APRLOPLL", 8)) {
+  if (is_internal_OPLL(slot)) {
     *((uint8_t *)arg) = slot;
   }
 }
 
 static void find_any_OPLL_callback(uint8_t slot, void * arg) {
-  if (!slot_bcmp(slot, (const void *)0x401c, "OPLL", 4)) {
+  if (is_OPLL(slot)) {
     *((uint8_t *)arg) = slot;
   }
 }
@@ -118,10 +198,10 @@ uint8_t find_OPLL(void) {
 
 static void list_OPLL_callback(uint8_t slot, void * arg) {
   (void)arg;                    // unused
-  if (!slot_bcmp(slot, (const void *)0x4018, "APRLOPLL", 8)) {
+  if (is_internal_OPLL(slot)) {
     puts(" (internal): "); print_slot(slot); putc('\n');
   }
-  else if (!slot_bcmp(slot, (const void *)0x401c, "OPLL", 4)) {
+  else if (is_OPLL(slot)) {
     puts(" \"");
     for (uint8_t i = 0; i < 8; ++i) {
       putc(msx_RDSLT(slot, (void *)(uintptr_t)(0x4018 + i)));
@@ -141,100 +221,201 @@ void list_OPLL(void) {
 
 // -----------------------------------------------------------------------
 
-struct z80_reg {
-  uint16_t af;
-  uint16_t bc;
-  uint16_t de;
-  uint16_t hl;
-};
+static void list_SCC_callback(uint8_t slot, void * arg) {
+  (void)arg;                    // unused
+  uint8_t scc_ver = SCC_inspect(slot);
+  if (1 < scc_ver) {
+    puts(" SCC+      : "); print_slot(slot); putc('\n');
+  }
+  else if (0 < scc_ver) {
+    puts(" SCC       : "); print_slot(slot); putc('\n');
+  }
+}
 
 /**
- * Wrapper for BDOS call.
- * \param reg [inout]  pointer to value of CPU registers.
+ * Print a list of detected Konami SCC/SCC+.
  */
-void bdos(uint8_t c, struct z80_reg * reg) {
-  (void)c;                      // A  --> C
-  (void)reg;                    // de --> IX
-  __asm__("push ix");
-  __asm__("ld c, a");
-  __asm__("push de");
-  __asm__("pop ix");
-  __asm__("ld a, 1 (ix)");
-  __asm__("ld b, 3 (ix)");
-  __asm__("ld e, 4 (ix)");
-  __asm__("ld d, 5 (ix)");
-  __asm__("ld l, 6 (ix)");
-  __asm__("ld h, 7 (ix)");
-  __asm__("push ix");
-  __asm__("call 0xf37d");
-  __asm__("pop ix");
-  __asm__("ld 1 (ix), a");
-  __asm__("ld 2 (ix), c");
-  __asm__("ld 3 (ix), b");
-  __asm__("ld 4 (ix), e");
-  __asm__("ld 5 (ix), d");
-  __asm__("ld 6 (ix), l");
-  __asm__("ld 7 (ix), h");
-  __asm__("pop ix");
+void list_SCC(void) {
+  puts("Konami SCC : slot"); putc('\n');
+  foreach_slot(list_SCC_callback, 0);
 }
 
 // -----------------------------------------------------------------------
 
-static volatile __at (0xfc9e) uint16_t JIFFY;
+void list_BDOS(void) {
+  puts("BDOS/FDC   : slot"); putc('\n');
+  const volatile uint8_t * p = DRVTBL;
+  while (*p) {
+    puts(" "); puti(p[0]); puts(" drives  : "); print_slot(p[1]);
+    if (p[1] == MASTERS) {
+      puts(" (master slot)");
+    }
+    putc('\n');
+    p += 2;
+  }
+}
 
-void main(void) {
-  screen1();
-  puts("CPU address: slot"); putc('\n');
-  puts(" C000..FFFF: "); print_slot(msx_get_slot((void *)0xc000)); putc('\n');
-  puts(" 8000..BFFF: "); print_slot(msx_get_slot((void *)0x8000)); putc('\n');
-  puts(" 4000..7FFF: "); print_slot(msx_get_slot((void *)0x4000)); putc('\n');
-  puts(" 0000..3FFF: "); print_slot(msx_get_slot((void *)0x0000)); putc('\n');
+void print_DOS_version(void) {
+  struct z80_reg reg;
+  bdos(0x6f, &reg);           // _DOSVER `DOS2` : Get MSX-DOS version
+  if (!(reg.af >> 8) && 2 <= (reg.bc >> 8)) {
+    // MSX-DOS 2.xx
+    putc('\n');
+    puts("MSX-DOS kernel version ");
+    puti(reg.bc >> 8); putc('.'); puti((reg.bc >> 4) & 15); puti((reg.bc) & 15); putc('\n');
+  }
+  else {
+    bdos(0x0c, &reg);         // _CPMVER `DOS1` `CP/M` : Get CP/M version
+    if (reg.hl == 0x0022) {
+      putc('\n');
+      puts("MSX-DOS kernel version 1.x"); putc('\n');
+    }
+  }
+}
+
+// -----------------------------------------------------------------------
+
+static void list_slot_callback(uint8_t slot, void * arg);
+
+/**
+ * Print the current memory map of CPU address space.
+ */
+void show_memory_map(void) {
+  cls();
+  puts("CPU address slot"); putc('\n');
+  puts("----------- ----"); putc('\n');
+  puts(" C000..FFFF "); print_slot(msx_get_slot((void *)0xc000)); putc('\n');
+  puts(" 8000..BFFF "); print_slot(msx_get_slot((void *)0x8000)); putc('\n');
+  puts(" 4000..7FFF "); print_slot(msx_get_slot((void *)0x4000)); putc('\n');
+  puts(" 0000..3FFF "); print_slot(msx_get_slot((void *)0x0000)); putc('\n');
   putc('\n');
+  // puts("slot page"); putc('\n');
+  // puts("---- ---- ----------------"); putc('\n');
+  // foreach_slot(list_slot_callback, 0);
+}
+
+static void list_slot_callback(uint8_t slot, void * arg) {
+  (void)arg;
+  puts(" "); print_slot(slot); puts(" ");
+
+  if (is_MAIN_ROM(slot)) {
+    puts("01__ MAIN ROM");
+  }
+  else if (is_SUB_ROM(slot)) {
+    puts("0___ SUB ROM");
+  }
+  else if (is_RAM(slot)) {
+    puts("0123 RAM");
+  }
+  else if (is_internal_OPLL(slot)) {
+    puts("_12_ MSX-MUSIC");
+  }
+  else if (is_FMPAC(slot)) {
+    puts("_12_ MSX-MUSIC (FMPAC)");
+  }
+  else if (is_OPLL(slot)) {
+    puts("_12_ MSX-MUSIC");
+    if (slot_bcmp(slot, (const void *)0x4018, "APRL", 4)) {
+      puts(" (");
+      const char * p = (const char *)0x4018;
+      for (uint8_t i = 4; i--; ) {
+        putc(msx_RDSLT(slot, (void *)p++));
+      }
+      __asm__("ei");
+      putc(')');
+    }
+  }
+  else if (is_SCCPlus(slot)) {
+    puts("_12_ SCC+ Sound Cartridge");
+  }
+  else if (is_SCC(slot)) {
+    puts("_12_ SCC MegaROM");
+  }
+  else if (is_BDOS(slot)) {
+    puts("_1__ BDOS/FDC");
+  }
+  else if (is_ROM_p1(slot)) {
+    if (is_ROM_p2(slot)) {
+      // probably mirrored
+      puts("_1__ 16K ROM");
+    }
+    else {
+      puts("_12_ 32K ROM");
+    }
+  }
+  else if (is_ROM_p2(slot)) {
+    puts("__2_ 16K ROM");
+  }
+  else {
+    puts("____ ");
+  }
+  putc('\n');
+}
+
+/**
+ * Prints a list of inspection results for each slot.
+ */
+void list_slots(void) {
+  puts("slot page"); putc('\n');
+  puts("---- ---- ----------------"); putc('\n');
+  foreach_slot(list_slot_callback, 0);
+}
+
+// -----------------------------------------------------------------------
+
+void show_system_environment(void) {
+  cls();
   puts("MSX BIOS   : slot"); putc('\n');
   puts(" MAIN ROM  : "); print_slot(EXPTBL[0]); putc('\n');
   if (0 < msx_get_version()) {
     // MSX2 or later
     puts(" SUB ROM   : "); print_slot(EXBRSA); putc('\n');
   }
-  putc('\n');
   if (find_OPLL()) {
+    putc('\n');
     list_OPLL();
   }
 
-  putc('\n');
-  if (DRVTBL[0]) {
-    puts("FDC        : slot"); putc('\n');
-    const volatile uint8_t * p = DRVTBL;
-    while (*p) {
-      puts("   "); puti(p[0]); puts(" drives: "); print_slot(p[1]);
-      if (p[1] == MASTERS) {
-        puts(" (master slot)");
-      }
-      putc('\n');
-      p += 2;
-    }
-
-    struct z80_reg reg;
-    bdos(0x6f, &reg);           // _DOSVER `DOS2` : Get MSX-DOS version
-    if (!(reg.af >> 8) && 2 <= (reg.bc >> 8)) {
-      // MSX-DOS 2.xx
-      putc('\n');
-      puts("MSX-DOS 2.x / Disk BASIC 2.x"); putc('\n');
-      puts(" kernel version ");
-      puti(reg.bc >> 8); putc('.'); puti((reg.bc >> 4) & 15); puti((reg.bc) & 15); putc('\n');
-    }
-    else {
-      bdos(0x0c, &reg);         // _CPMVER `DOS1` `CP/M` : Get CP/M version
-      if (reg.hl == 0x0022) {
-        putc('\n');
-        puts("MSX-DOS 1.x / Disk BASIC 1.x");
-      }
-    }
+  struct SCC scc;
+  SCC_find(&scc);
+  if (scc.slot) {
+    putc('\n');
+    list_SCC();
   }
 
+  if (DRVTBL[0]) {
+    putc('\n');
+    list_BDOS();
+    print_DOS_version();
+  }
+}
+
+// -----------------------------------------------------------------------
+
+static volatile __at (0xfc9e) uint16_t JIFFY;
+
+void show_timer(void) {
+  locate(0,23);
+  puts("TIME: "); puti(JIFFY); puts("     ");
+}
+
+void show_timer_loop(void) {
+  uint16_t t = 5 * msx_get_vsync_frequency();
+  while (t--) {
+    await_vsync();
+    show_timer();
+  }
+}
+
+void main(void) {
+  screen1();
+
   for (;;) {
-    // await_vsync();
-    locate(0,23);
-    puts("TIME: "); puti(JIFFY); puts("     ");
+    show_memory_map();
+    list_slots();
+    show_timer_loop();
+
+    show_system_environment();
+    show_timer_loop();
   }
 }

--- a/sample/check_slots/src/scc.c
+++ b/sample/check_slots/src/scc.c
@@ -1,0 +1,59 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file scc.c
+ */
+
+#include <msx.h>
+#include <stdint.h>
+
+#include "scc.h"
+
+extern int slot_bcmp(uint8_t slot, const void * addr, const void * s, size_t len);
+extern void foreach_slot(void (*callback)(uint8_t slot, void * arg), void * arg);
+
+extern bool is_read_only(uint8_t slot, void * addr);
+
+uint8_t SCC_inspect(uint8_t slot) {
+  if (!is_read_only(slot, (void *)0x8000)) {
+    return 0;
+  }
+  msx_WRSLT(slot, (void *)&SCCPlus_mode_select, 0x00);
+  msx_WRSLT(slot, (void *)&SCC_BANK_SELECT_2, 0x00);
+  if (!is_read_only(slot, (void *)SCC_waveform)) {
+    return 0;
+  }
+  msx_WRSLT(slot, (void *)&SCC_BANK_SELECT_2, 0x3f);
+  if (is_read_only(slot, (void *)SCC_waveform)) {
+    return 0;
+  }
+  msx_WRSLT(slot, (void *)&SCCPlus_mode_select, 0x20);
+  msx_WRSLT(slot, (void *)&SCC_BANK_SELECT_3, 0x80);
+  if (is_read_only(slot, (void *)SCCPlus_waveform)) {
+    return 1;                   // SCC MegaROM
+  }
+  return 2;                     // SCC+ Sound Cartridge
+}
+
+static void SCC_find_callback(uint8_t slot, void * arg) {
+  uint8_t x = SCC_inspect(slot);
+  if (!x) return;
+
+  struct SCC * scc = (struct SCC *)arg;
+  scc->slot = slot;
+  scc->version = x;             // 1: SCC, 2: SCC+
+}
+
+void SCC_find(struct SCC * scc) {
+  scc->slot = 0;
+  scc->version = 0;
+  foreach_slot(SCC_find_callback, scc);
+}

--- a/sample/check_slots/src/scc.h
+++ b/sample/check_slots/src/scc.h
@@ -1,0 +1,67 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file scc.h
+ */
+
+#pragma once
+
+#ifndef SCC_H_
+#define SCC_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <config.h>
+
+volatile static __at(0x5000) uint8_t  SCC_BANK_SELECT_0;
+volatile static __at(0x7000) uint8_t  SCC_BANK_SELECT_1;
+volatile static __at(0x9000) uint8_t  SCC_BANK_SELECT_2;
+volatile static __at(0xb000) uint8_t  SCC_BANK_SELECT_3;
+
+volatile static __at(0x9800) int8_t   SCC_waveform[4][32]; // channel 1..4
+volatile static __at(0x9880) uint16_t SCC_fdr[5];
+volatile static __at(0x988a) uint8_t  SCC_volume[5];
+volatile static __at(0x988f) uint8_t  SCC_channel_mask;
+
+volatile static __at(0x98a0) int8_t   SCC_waveform5[32]; // channel 5 (readonly)
+volatile static __at(0x98e0) uint8_t  SCC_deformation;
+
+volatile static __at(0xb800) int8_t   SCCPlus_waveform[5][32];
+volatile static __at(0xb8a0) uint16_t SCCPlus_fdr[5];
+volatile static __at(0xb8aa) uint8_t  SCCPlus_volume[5];
+volatile static __at(0xb8af) uint8_t  SCCPlus_channel_mask;
+
+volatile static __at(0xb8c0) uint8_t  SCCPlus_deformation;
+
+volatile static __at(0xbffe) uint8_t  SCCPlus_mode_select;
+
+struct SCC_channel {
+  void (* read_waveform)(int8_t data[32]);
+  void (* write_waveform)(const int8_t data[32]);
+  void (* read_fdr)(uint16_t * fdr);
+  void (* write_fdr)(const uint16_t fdr);
+  void (* read_volume)(uint8_t * volume);
+  void (* write_volume)(const uint8_t volume);
+};
+struct SCC {
+  uint8_t slot;
+  uint8_t version;              // 1: SCC, 2: SCC+
+  uint8_t (* read_channel_mask)(void);
+  void (* write_channel_mask)(const uint8_t mask);
+  void (* write_deformation)(const uint8_t value);
+  struct SCC_channel channels[5];
+};
+
+uint8_t SCC_inspect(uint8_t slot);
+void SCC_find(struct SCC * scc);
+
+#endif // SCC_H_

--- a/src/msx_CHGCPU.c
+++ b/src/msx_CHGCPU.c
@@ -17,19 +17,29 @@
 
 void msx_CHGCPU(const uint8_t mode) __naked {
   ((void)mode);
+  __asm__("push af");
   __asm__("and a, #0x83");
-  __asm__("jp _CHGCPU");
+  __asm__("call _CHGCPU");
+  __asm__("pop af");
+  __asm__("ret");
 }
 
 #else
 
 void msx_CHGCPU(const uint8_t mode) __naked {
   ((void)mode);
-  __asm__("ld hl, #2+0");
+  __asm__("push af");
+  __asm__("push hl");
+
+  __asm__("ld hl, #6");
   __asm__("add hl, sp");
   __asm__("ld a, (hl)");
   __asm__("and a, #0x83");
-  __asm__("jp _CHGCPU");
+  __asm__("call _CHGCPU");
+
+  __asm__("pop hl");
+  __asm__("pop af");
+  __asm__("ret");
 }
 
 #endif

--- a/src/msx_ENASLT.c
+++ b/src/msx_ENASLT.c
@@ -18,9 +18,44 @@
 void msx_ENASLT(uint8_t slot, void * addr) __naked {
   (void)slot;                   // A  --> A
   (void)addr;                   // DE --> HL
+  __asm__("push af");
+  __asm__("push bc");
+  __asm__("push de");
+  __asm__("push hl");
+  __asm__("push ix");
+  __asm__("push iy");
+
   __asm__("ld h, d");
   __asm__("ld l, e");
-  __asm__("jp _ENASLT");
+
+  __asm__("ex af, af'");
+  __asm__("exx");
+  __asm__("push af");
+  __asm__("push bc");
+  __asm__("push de");
+  __asm__("push hl");
+  __asm__("ex af, af'");
+  __asm__("exx");
+
+  __asm__("call _ENASLT");
+
+  __asm__("ex af, af'");
+  __asm__("exx");
+  __asm__("pop hl");
+  __asm__("pop de");
+  __asm__("pop bc");
+  __asm__("pop af");
+  __asm__("ex af, af'");
+  __asm__("exx");
+
+  __asm__("pop iy");
+  __asm__("pop ix");
+  __asm__("pop hl");
+  __asm__("pop de");
+  __asm__("pop bc");
+  __asm__("pop af");
+
+  __asm__("ret");
 }
 
 #else
@@ -28,14 +63,47 @@ void msx_ENASLT(uint8_t slot, void * addr) __naked {
 void msx_ENASLT(uint8_t slot, void * addr) __naked {
   (void)slot;                   // (SP+2) --> A
   (void)addr;                   // (SP+3) --> HL
+  __asm__("push af");
+  __asm__("push bc");
+  __asm__("push de");
+  __asm__("push hl");
   __asm__("push ix");
-  __asm__("ld ix, #0");
+  __asm__("push iy");
+
+  __asm__("ld ix, #12");
   __asm__("add ix, sp");
-  __asm__("ld a, 4 (ix)");
-  __asm__("ld l, 5 (ix)");
-  __asm__("ld h, 6 (ix)");
+  __asm__("ld a, 2 (ix)");
+  __asm__("ld l, 3 (ix)");
+  __asm__("ld h, 4 (ix)");
+
+  __asm__("ex af, af'");
+  __asm__("exx");
+  __asm__("push af");
+  __asm__("push bc");
+  __asm__("push de");
+  __asm__("push hl");
+  __asm__("ex af, af'");
+  __asm__("exx");
+
+  __asm__("call _ENASLT");
+
+  __asm__("ex af, af'");
+  __asm__("exx");
+  __asm__("pop hl");
+  __asm__("pop de");
+  __asm__("pop bc");
+  __asm__("pop af");
+  __asm__("ex af, af'");
+  __asm__("exx");
+
+  __asm__("pop iy");
   __asm__("pop ix");
-  __asm__("jp _ENASLT");
+  __asm__("pop hl");
+  __asm__("pop de");
+  __asm__("pop bc");
+  __asm__("pop af");
+
+  __asm__("ret");
 }
 
 #endif

--- a/src/msx_GETCPU.c
+++ b/src/msx_GETCPU.c
@@ -22,8 +22,10 @@ uint8_t msx_GETCPU(void) __naked {
 #else
 
 uint8_t msx_GETCPU(void) __naked {
+  __asm__("push af");
   __asm__("call _GETCPU");
   __asm__("ld l, a");
+  __asm__("pop af");
   __asm__("ret");
 }
 

--- a/src/msx_GTSTCK.c
+++ b/src/msx_GTSTCK.c
@@ -16,24 +16,84 @@
 #if (__SDCCCALL == 1)
 
 uint8_t msx_GTSTCK(const uint8_t a) __naked {
-  ((void)a);
-  __asm__("push ix");           // save IX register (frame pointer)
+  ((void)a);                    // A --> A
+  __asm__("push bc");
+  __asm__("push de");
+  __asm__("push hl");
+  __asm__("push ix");
+  __asm__("push iy");
+
+  __asm__("ex af, af'");
+  __asm__("exx");
+  __asm__("push af");
+  __asm__("push bc");
+  __asm__("push de");
+  __asm__("push hl");
+  __asm__("ex af, af'");
+  __asm__("exx");
+
   __asm__("call _GTSTCK");
-  __asm__("pop  ix");           // restore IX register
+
+  __asm__("ex af, af'");
+  __asm__("exx");
+  __asm__("pop hl");
+  __asm__("pop de");
+  __asm__("pop bc");
+  __asm__("pop af");
+  __asm__("ex af, af'");
+  __asm__("exx");
+
+  __asm__("pop  iy");
+  __asm__("pop  ix");
+  __asm__("pop  hl");
+  __asm__("pop  de");
+  __asm__("pop  bc");
   __asm__("ret");
 }
 
 #else
 
 uint8_t msx_GTSTCK(const uint8_t a) __naked {
-  ((void)a);
-  __asm__("ld   hl, #2");
-  __asm__("add  hl, sp");
-  __asm__("ld   a, (hl)");
-  __asm__("push ix");           // save IX register (frame pointer)
+  ((void)a);                    // (sp+2) --> A
+  __asm__("push af");
+  __asm__("push bc");
+  __asm__("push de");
+  __asm__("push hl");
+  __asm__("push ix");
+  __asm__("push iy");
+
+  __asm__("ld ix, #12");
+  __asm__("add ix, sp");
+  __asm__("ld a, 2 (ix)");
+
+  __asm__("ex af, af'");
+  __asm__("exx");
+  __asm__("push af");
+  __asm__("push bc");
+  __asm__("push de");
+  __asm__("push hl");
+  __asm__("ex af, af'");
+  __asm__("exx");
+
   __asm__("call _GTSTCK");
-  __asm__("ld   l, a");
-  __asm__("pop  ix");           // restore IX register
+
+  __asm__("ex af, af'");
+  __asm__("exx");
+  __asm__("pop hl");
+  __asm__("pop de");
+  __asm__("pop bc");
+  __asm__("pop af");
+  __asm__("ex af, af'");
+  __asm__("exx");
+
+  __asm__("pop iy");
+  __asm__("pop ix");
+  __asm__("pop hl");
+  __asm__("ld l, a");
+  __asm__("pop de");
+  __asm__("pop bc");
+  __asm__("pop af");
+
   __asm__("ret");
 }
 

--- a/src/msx_GTTRIG.c
+++ b/src/msx_GTTRIG.c
@@ -16,19 +16,23 @@
 #if (__SDCCCALL == 1)
 
 uint8_t msx_GTTRIG(const uint8_t a) __naked {
-  ((void)a);
+  ((void)a);                    // A --> A
   __asm__("jp _GTTRIG");
 }
 
 #else
 
 uint8_t msx_GTTRIG(const uint8_t a) __naked {
-  ((void)a);
-  __asm__("ld   hl, #2");
+  ((void)a);                    // (sp+2) --> A
+  __asm__("push af");
+  __asm__("push hl");
+  __asm__("ld   hl, #6");
   __asm__("add  hl, sp");
   __asm__("ld   a, (hl)");
   __asm__("call _GTTRIG");
+  __asm__("pop hl");
   __asm__("ld   l, a");
+  __asm__("pop af");
   __asm__("ret");
 }
 

--- a/src/msx_RDSLT.c
+++ b/src/msx_RDSLT.c
@@ -18,9 +18,20 @@
 uint8_t msx_RDSLT(uint8_t slot, void * addr) __naked {
   (void)slot;                   // A  --> A
   (void)addr;                   // DE --> HL
+  __asm__("push bc");
+  __asm__("push de");
+  __asm__("push hl");
+
   __asm__("ld h, d");
   __asm__("ld l, e");
-  __asm__("jp _RDSLT");
+
+  __asm__("call _RDSLT");
+
+  __asm__("pop hl");
+  __asm__("pop de");
+  __asm__("pop bc");
+
+  __asm__("ret");
 }
 
 #else
@@ -28,15 +39,27 @@ uint8_t msx_RDSLT(uint8_t slot, void * addr) __naked {
 uint8_t msx_RDSLT(uint8_t slot, void * addr) __naked {
   (void)slot;                   // (SP+2) --> A
   (void)addr;                   // (SP+3) --> HL
+  __asm__("push af");
+  __asm__("push bc");
+  __asm__("push de");
+  __asm__("push hl");
   __asm__("push ix");
-  __asm__("ld ix, #0");
+
+  __asm__("ld ix, #10");
   __asm__("add ix, sp");
-  __asm__("ld a, 4 (ix)");
-  __asm__("ld l, 5 (ix)");
-  __asm__("ld h, 6 (ix)");
-  __asm__("pop ix");
+  __asm__("ld a, 2 (ix)");
+  __asm__("ld l, 3 (ix)");
+  __asm__("ld h, 4 (ix)");
+
   __asm__("call _RDSLT");
+
+  __asm__("pop ix");
+  __asm__("pop hl");
   __asm__("ld l, a");
+  __asm__("pop de");
+  __asm__("pop bc");
+  __asm__("pop af");
+
   __asm__("ret");
 }
 

--- a/src/msx_RSLREG.c
+++ b/src/msx_RSLREG.c
@@ -22,8 +22,10 @@ uint8_t msx_RSLREG(void) __naked {
 #else
 
 uint8_t msx_RSLREG(void) __naked {
+  __asm__("push af");
   __asm__("call _RSLREG");
   __asm__("ld l, a");
+  __asm__("pop af");
   __asm__("ret");
 }
 

--- a/src/msx_WRSLT.c
+++ b/src/msx_WRSLT.c
@@ -13,34 +13,34 @@
 
 #include "../include/bios.h"
 
-#if (__SDCCCALL == 1)
+#ifndef __SDCCCALL
+#define __sdcccall(x)
+#endif
 
-void msx_WRSLT(uint8_t slot, void * addr, uint8_t value) __naked {
-  (void)slot;                   // A      --> A
-  (void)addr;                   // DE     --> HL
-  (void)value;                  // (SP+2) --> E
-  __asm__("ld hl, #2");
-  __asm__("add hl, sp");
-  __asm__("ld l, (hl)");
-  __asm__("ex de, hl");
-  __asm__("jp _WRSLT");
-}
-
-#else
-
-void msx_WRSLT(uint8_t slot, void * addr, uint8_t value) __naked {
+void msx_WRSLT(uint8_t slot, void * addr, uint8_t value) __sdcccall(0) __naked {
   (void)slot;                   // (SP+2) --> A
   (void)addr;                   // (SP+3) --> HL
   (void)value;                  // (SP+5) --> E
+  __asm__("push af");
+  __asm__("push bc");
+  __asm__("push de");
+  __asm__("push hl");
   __asm__("push ix");
-  __asm__("ld ix, #0");
-  __asm__("add ix, sp");
-  __asm__("ld a, 4 (ix)");
-  __asm__("ld l, 5 (ix)");
-  __asm__("ld h, 6 (ix)");
-  __asm__("ld e, 7 (ix)");
-  __asm__("pop ix");
-  __asm__("jp _WRSLT");
-}
 
-#endif
+  __asm__("ld ix, #10");
+  __asm__("add ix, sp");
+  __asm__("ld a, 2 (ix)");
+  __asm__("ld l, 3 (ix)");
+  __asm__("ld h, 4 (ix)");
+  __asm__("ld e, 5 (ix)");
+
+  __asm__("call _WRSLT");
+
+  __asm__("pop ix");
+  __asm__("pop hl");
+  __asm__("pop de");
+  __asm__("pop bc");
+  __asm__("pop af");
+
+  __asm__("ret");
+}

--- a/src/msx_WSLREG.c
+++ b/src/msx_WSLREG.c
@@ -24,12 +24,15 @@ void msx_WSLREG(uint8_t value) __naked {
 
 void msx_WSLREG(uint8_t value) __naked {
   (void)value;                  // (sp+2) --> A
+  __asm__("push af");
   __asm__("push ix");
-  __asm__("ld ix, #0");
+  __asm__("ld ix, #4");
   __asm__("add ix, sp");
-  __asm__("ld a, 4 (ix)");
+  __asm__("ld a, 2 (ix)");
   __asm__("pop ix");
-  __asm__("jp _WSLREG");
+  __asm__("call _WSLREG");
+  __asm__("pop af");
+  __asm__("ret");
 }
 
 #endif


### PR DESCRIPTION
Fixed a discrepancy between the BIOS I/F and SDCC calling conventions.

Also, `msx_WRSLT()` is now forced to use the `__sdcccall(0)` calling convention since using the default `__sdcccall(1)` calling convention seems to break the calling code generated by SDCC 4.2.0.

`sample/check_slots` is also updated. Added feature of SCC/SCC+ detection.