### PR TITLE
fix(VDP) some bugfix

### DIFF
--- a/include/vdp.h
+++ b/include/vdp.h
@@ -24,58 +24,10 @@
 
 #include "io.h"
 #include "vmem.h"
+#include "vdp_unsafe.h"
 
 #include "bios.h"
 #include "workarea.h"
-
-inline void VDP_SET_CONTROL_REGISTER(uint8_t reg, uint8_t val) {
-  vdp_port1 = val;
-  vdp_port1 = reg | 0x80;
-}
-
-inline void VDP_SET_CONTROL_REGISTER_POINTER(uint8_t reg) {
-  VDP_SET_CONTROL_REGISTER(17, reg | 0x80);
-}
-
-inline void VDP_SET_CONTROL_REGISTER_POINTER_AUTO_INCREMENT(uint8_t reg) {
-  VDP_SET_CONTROL_REGISTER(17, reg);
-}
-
-inline void VDP_SET_CONTROL_REGISTER_VALUE(uint8_t val) {
-  vdp_port3 = val;
-}
-
-inline void VDP_SET_STATUS_REGISTER_POINTER(uint8_t reg) {
-  VDP_SET_CONTROL_REGISTER(15, reg);
-}
-
-inline uint8_t VDP_GET_STATUS_REGISTER_VALUE(void) {
-  return vdp_port1;
-}
-
-inline void VDP_SET_VMEM_WRITE_POINTER(vmemptr_t loc) {
-  if (0 < msx_get_version()) {
-    VDP_SET_CONTROL_REGISTER(14, (uint8_t)(((loc) >> 14) & 7));
-  }
-  vdp_port1 = (uint8_t)((loc) & 255);
-  vdp_port1 = (uint8_t)(((loc) >> 8) & 0x3F | 0x40);
-}
-
-inline void VDP_SET_VMEM_READ_POINTER(vmemptr_t loc) {
-  if (0 < msx_get_version()) {
-    VDP_SET_CONTROL_REGISTER(14, (uint8_t)(((loc) >> 14) & 7));
-  }
-  vdp_port1 = (uint8_t)((loc) & 255);
-  vdp_port1 = (uint8_t)(((loc) >> 8) & 0x3F);
-}
-
-inline void VDP_SET_VMEM_VALUE(uint8_t val) {
-  vdp_port0 = val;
-}
-
-inline uint8_t VDP_GET_VMEM_VALUE(void) {
-  return vdp_port0;
-}
 
 // ---- VDP status register
 

--- a/include/vdp.h
+++ b/include/vdp.h
@@ -83,7 +83,21 @@ inline uint8_t VDP_GET_VMEM_VALUE(void) {
  * `MSX` Read from a VDP status register.
  *
  * \param reg  VDP status register number.
+ *             - `MSX` : `0`
+ *             - `MSX2`: `0`..`9`
+ *             - If any other value was specified, behaviour is undefined.
  * \return     Value of the VDP status register.
+ *             - If `reg != 0`, returns the value of the status register #`reg`
+ *             - If `reg == 0`, returns the value of `STATFL` instead of
+ *               reading the status register #0 (S#0).
+ *
+ * \note
+ * The MSX SYSTEM interrupt routine reads S#0 to see if an interrupt due to
+ * VSYNC has occurred. Also, reading S#0 resets bit #7 (VSYNC interrupt flag) of
+ * S#0, so the latest value read from S#0 is stored in `STATFL` for other uses.
+ * Therefore, this function reads `STATFL` instead of S#0 if `reg == 0`.
+ *
+ * \sa STATFL
  */
 uint8_t vdp_get_status(uint8_t reg);
 

--- a/include/vdp.h
+++ b/include/vdp.h
@@ -1,6 +1,6 @@
 // -*- coding: utf-8-unix -*-
 /*
- * Copyright (c) 2021 Daishi Mori (mori0091)
+ * Copyright (c) 2021-2022 Daishi Mori (mori0091)
  *
  * This software is released under the MIT License.\n
  * See https://github.com/mori0091/libmsx/blob/main/LICENSE
@@ -119,25 +119,25 @@ void vdp_write_palette(const palette_t palettes[16]);
  */
 enum vdp_screen_mode {
   /** `MSX` GRAPHIC 1 (SCREEN 1) */
-  VDP_SCREEN_MODE_GRAPHIC_1   = 0, // 00000b (00) SCREEN 1
+  VDP_SCREEN_MODE_GRAPHIC_1   = 0, // SCREEN 1
   /** `MSX` TEXT 1 (SCREEN 0, WIDTH 40)*/
-  VDP_SCREEN_MODE_TEXT_1      = 1, // 00001b (01) SCREEN 0: WIDTH 40
+  VDP_SCREEN_MODE_TEXT_1      = 1, // SCREEN 0: WIDTH 40
   /** `MSX` MULTI COLOR (SCREEN 3) */
-  VDP_SCREEN_MODE_MULTI_COLOR = 2, // 00010b (02) SCREEN 3
+  VDP_SCREEN_MODE_MULTI_COLOR = 2, // SCREEN 3
   /** `MSX` GRAPHIC 2 (SCREEN 2) */
-  VDP_SCREEN_MODE_GRAPHIC_2   = 3, // 00100b (04) SCREEN 2
+  VDP_SCREEN_MODE_GRAPHIC_2   = 3, // SCREEN 2
   /** `MSX2` GRAPHIC 3 (SCREEN 4) */
-  VDP_SCREEN_MODE_GRAPHIC_3   = 4, // 01000b (08) SCREEN 4
+  VDP_SCREEN_MODE_GRAPHIC_3   = 4, // SCREEN 4
   /** `MSX2` TEXT 2 (SCREEN 0, WIDTH 80)*/
-  VDP_SCREEN_MODE_TEXT_2      = 5, // 01001b (09) SCREEN 0: WIDTH 80
+  VDP_SCREEN_MODE_TEXT_2      = 5, // SCREEN 0: WIDTH 80
   /** `MSX2` GRAPHIC 4 (SCREEN 5) */
-  VDP_SCREEN_MODE_GRAPHIC_4   = 6, // 01100b (0C) SCREEN 5
+  VDP_SCREEN_MODE_GRAPHIC_4   = 6, // SCREEN 5
   /** `MSX2` GRAPHIC 5 (SCREEN 6) */
-  VDP_SCREEN_MODE_GRAPHIC_5   = 7, // 10000b (10) SCREEN 6
+  VDP_SCREEN_MODE_GRAPHIC_5   = 7, // SCREEN 6
   /** `MSX2` GRAPHIC 6 (SCREEN 7) */
-  VDP_SCREEN_MODE_GRAPHIC_6   = 8, // 10100b (14) SCREEN 7
+  VDP_SCREEN_MODE_GRAPHIC_6   = 8, // SCREEN 7
   /** `MSX2` GRAPHIC 7 (SCREEN 8) */
-  VDP_SCREEN_MODE_GRAPHIC_7   = 9, // 11100b (1C) SCREEN 8
+  VDP_SCREEN_MODE_GRAPHIC_7   = 9, // SCREEN 8
 };
 
 /**

--- a/include/vdp.h
+++ b/include/vdp.h
@@ -112,7 +112,7 @@ uint8_t vdp_get_status(uint8_t reg);
 void vdp_set_control(uint8_t reg, uint8_t x);
 
 /**
- * `MSX` Write to a series of VDP control registers.
+ * `MSX2` Write to a series of VDP control registers.
  *
  * \param reg  First number of the VDP control register.
  * \param src  Pointer to the beginning of the value to be written.

--- a/include/vdp_unsafe.h
+++ b/include/vdp_unsafe.h
@@ -1,0 +1,199 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2021 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file vdp_unsafe.h
+ * \brief Unsafe primitive functions for VDP (Video Display Proccessor) access.
+ */
+
+#pragma once
+
+#ifndef VDP_UNSAFE_H_
+#define VDP_UNSAFE_H_
+
+#include <stdint.h>
+
+#include "io.h"
+#include "vmem.h"
+#include "bios.h"
+
+/**
+ * `MSX` Write a value to the specified VDP control register.
+ *
+ * \param reg  VDP control register number.
+ * \param val  Value to be written.
+ *
+ * \attention
+ * Unsafe but fast.
+ *
+ * \sa vdp_set_control()
+ */
+inline void VDP_SET_CONTROL_REGISTER(uint8_t reg, uint8_t val) {
+  vdp_port1 = val;
+  vdp_port1 = reg | 0x80;
+}
+
+/**
+ * `MSX2` Set VDP control register number for subsequent writing to the VDP
+ * control register.
+ *
+ * \param reg  VDP control register number.
+ *
+ * \attention
+ * Unsafe but fast.
+ *
+ * \note
+ * Same as `VDP_SET_CONTROL_REGISTER(17, reg | 0x80)`.
+ *
+ * \sa VDP_SET_CONTROL_REGISTER_VALUE()
+ */
+inline void VDP_SET_CONTROL_REGISTER_POINTER(uint8_t reg) {
+  VDP_SET_CONTROL_REGISTER(17, reg | 0x80);
+}
+
+/**
+ * `MSX2` Set VDP control register number for subsequent writing to the series
+ * of VDP control registers.
+ *
+ * \param reg  VDP control register number.
+ *
+ * \attention
+ * Unsafe but fast.
+ *
+ * \note
+ * Same as `VDP_SET_CONTROL_REGISTER(17, reg)`.
+ *
+ * \sa VDP_SET_CONTROL_REGISTER_VALUE()
+ * \sa vdp_write_control()
+ */
+inline void VDP_SET_CONTROL_REGISTER_POINTER_AUTO_INCREMENT(uint8_t reg) {
+  VDP_SET_CONTROL_REGISTER(17, reg);
+}
+
+/**
+ * `MSX2` Write a value to the VDP control register pointed by R#17.
+ *
+ * \param val  a value.
+ *
+ * \attention
+ * Unsafe but fast.
+ *
+ * \sa VDP_SET_CONTROL_REGISTER_POINTER()
+ * \sa VDP_SET_CONTROL_REGISTER_POINTER_AUTO_INCREMENT()
+ */
+inline void VDP_SET_CONTROL_REGISTER_VALUE(uint8_t val) {
+  vdp_port3 = val;
+}
+
+/**
+ * `MSX2` Set VDP status register number for subsequent reading from the VDP
+ * status register.
+ *
+ * \param reg  VDP status register number.
+ *
+ * \attention
+ * Unsafe but fast.
+ *
+ * \note
+ * Same as `VDP_SET_CONTROL_REGISTER(15, reg)`.
+ *
+ * \sa VDP_GET_STATUS_REGISTER_VALUE()
+ * \sa vdp_get_status()
+ */
+inline void VDP_SET_STATUS_REGISTER_POINTER(uint8_t reg) {
+  VDP_SET_CONTROL_REGISTER(15, reg);
+}
+
+/**
+ * `MSX` Reads a value from VDP status register.
+ *
+ * \return a value.
+ *
+ * \attention
+ * Unsafe but fast.
+ *
+ * \sa vdp_get_status()
+ */
+inline uint8_t VDP_GET_STATUS_REGISTER_VALUE(void) {
+  return vdp_port1;
+}
+
+/**
+ * `MSX` Set VRAM address for subsequent writing to VRAM.
+ *
+ * \param loc  VRAM address.
+ *
+ * \attention
+ * Unsafe but fast.
+ *
+ * \sa VDP_SET_VMEM_VALUE()
+ * \sa vmem_set_write_address()
+ */
+inline void VDP_SET_VMEM_WRITE_POINTER(vmemptr_t loc) {
+  if (0 < msx_get_version()) {
+    VDP_SET_CONTROL_REGISTER(14, (uint8_t)(((loc) >> 14) & 7));
+  }
+  vdp_port1 = (uint8_t)((loc) & 255);
+  vdp_port1 = (uint8_t)(((loc) >> 8) & 0x3F | 0x40);
+}
+
+/**
+ * `MSX` Set VRAM address for subsequent reading from VRAM.
+ *
+ * \param loc  VRAM address.
+ *
+ * \attention
+ * Unsafe but fast.
+ *
+ * \sa VDP_GET_VMEM_VALUE()
+ * \sa vmem_set_read_address()
+ */
+inline void VDP_SET_VMEM_READ_POINTER(vmemptr_t loc) {
+  if (0 < msx_get_version()) {
+    VDP_SET_CONTROL_REGISTER(14, (uint8_t)(((loc) >> 14) & 7));
+  }
+  vdp_port1 = (uint8_t)((loc) & 255);
+  vdp_port1 = (uint8_t)(((loc) >> 8) & 0x3F);
+}
+
+/**
+ * `MSX` Write a value to VRAM.
+ *
+ * \param val  a value.
+ *
+ * \attention
+ * Unsafe but fast.
+ *
+ * \sa VDP_SET_VMEM_WRITE_POINTER()
+ * \sa vmem_set()
+ * \sa vmem_write()
+ * \sa vmem_memset()
+ */
+inline void VDP_SET_VMEM_VALUE(uint8_t val) {
+  vdp_port0 = val;
+}
+
+/**
+ * `MSX` Read a value from VRAM.
+ *
+ * \return a value.
+ *
+ * \attention
+ * Unsafe but fast.
+ *
+ * \sa VDP_SET_VMEM_READ_POINTER()
+ * \sa vmem_get()
+ * \sa vmem_read()
+ */
+inline uint8_t VDP_GET_VMEM_VALUE(void) {
+  return vdp_port0;
+}
+
+#endif // VDP_UNSAFE_H_

--- a/include/workarea.h
+++ b/include/workarea.h
@@ -33,6 +33,8 @@ static volatile __at (0xf3e4) uint8_t RG5SAV; ///< `MSX` Saved value for VDP R#5
 static volatile __at (0xf3e5) uint8_t RG6SAV; ///< `MSX` Saved value for VDP R#6 register.
 static volatile __at (0xf3e6) uint8_t RG7SAV; ///< `MSX` Saved value for VDP R#7 register.
 
+static volatile __at (0xf3e7) uint8_t STATFL; ///< `MSX` Saved value for VDP S#0 register.
+
 static volatile __at (0xffe7) uint8_t RG8SAV; ///< `MSX2` Saved value for VDP R#8 register.
 static volatile __at (0xffe8) uint8_t RG9SAV; ///< `MSX2` Saved value for VDP R#9 register.
 static volatile __at (0xffe9) uint8_t RG10SA; ///< `MSX2` Saved value for VDP R#10 register.

--- a/src/vdp.c
+++ b/src/vdp.c
@@ -1,19 +1,20 @@
 // -*- coding: utf-8-unix -*-
-/**
- * \file vdp.c
- *
- * Copyright (c) 2021 Daishi Mori (mori0091)
+/*
+ * Copyright (c) 2021-2022 Daishi Mori (mori0091)
  *
  * This software is released under the MIT License.
  * See https://github.com/mori0091/libmsx/blob/main/LICENSE
  *
- * GitHub libmsx project
+ * GitHub libmsx project\n
  * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file vdp.c
  */
 
 #include "../include/vdp.h"
 
 #include "vdp_internal.h"
 
-volatile enum vdp_screen_mode screen_mode = 0;
-volatile uint8_t sprite_mode = 0;
+volatile enum vdp_screen_mode screen_mode = VDP_SCREEN_MODE_GRAPHIC_1;
+volatile uint8_t sprite_mode = 1;

--- a/src/vdp_get_status.c
+++ b/src/vdp_get_status.c
@@ -1,8 +1,6 @@
 // -*- coding: utf-8-unix -*-
-/**
- * \file vdp_get_status.c
- *
- * Copyright (c) 2021 Daishi Mori (mori0091)
+/*
+ * Copyright (c) 2021-2022 Daishi Mori (mori0091)
  *
  * This software is released under the MIT License.
  * See https://github.com/mori0091/libmsx/blob/main/LICENSE
@@ -10,12 +8,19 @@
  * GitHub libmsx project
  * https://github.com/mori0091/libmsx
  */
+/**
+ * \file vdp_get_status.c
+ */
 
 #include "../include/vdp.h"
 
 #include "vdp_internal.h"
 
 uint8_t vdp_get_status(uint8_t reg) {
+  if (!reg) {
+    return STATFL;
+  }
+
   volatile uint8_t x;
   __asm__("di");
   VDP_SET_STATUS_REGISTER_POINTER(reg);

--- a/src/vdp_set_screen_mode.c
+++ b/src/vdp_set_screen_mode.c
@@ -1,71 +1,49 @@
 // -*- coding: utf-8-unix -*-
-/**
- * \file vdp_set_screen_mode.c
- *
- * Copyright (c) 2021 Daishi Mori (mori0091)
+/*
+ * Copyright (c) 2021-2022 Daishi Mori (mori0091)
  *
  * This software is released under the MIT License.
  * See https://github.com/mori0091/libmsx/blob/main/LICENSE
  *
- * GitHub libmsx project
+ * GitHub libmsx project\n
  * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file vdp_set_screen_mode.c
  */
 
 #include "../include/vdp.h"
 
 #include "vdp_internal.h"
 
+struct screen_mode_vec {        // |b7|b6|b5|b4|b3|b2|b1|b0|
+  uint8_t r0;                   // | 0| 0| 0| 0|M5|M4|M3| 0|
+  uint8_t r1;                   // | 0| 0| 0|M1|M2| 0| 0| 0|
+  uint8_t sprite_mode;
+};
+
+static const struct screen_mode_vec screen_mode_vecs[] = {
+  // `MSX`
+  [VDP_SCREEN_MODE_GRAPHIC_1]   = { .r0 = 0x00, .r1 = 0x00, .sprite_mode = 1 }, // SCREEN 1
+  [VDP_SCREEN_MODE_TEXT_1]      = { .r0 = 0x00, .r1 = 0x10, .sprite_mode = 0 }, // SCREEN 0, WIDTH 40
+  [VDP_SCREEN_MODE_MULTI_COLOR] = { .r0 = 0x00, .r1 = 0x08, .sprite_mode = 1 }, // SCREEN 3
+  [VDP_SCREEN_MODE_GRAPHIC_2]   = { .r0 = 0x02, .r1 = 0x00, .sprite_mode = 1 }, // SCREEN 2
+  // `MSX2`
+  [VDP_SCREEN_MODE_TEXT_2]      = { .r0 = 0x04, .r1 = 0x10, .sprite_mode = 0 }, // SCREEN 0, WIDTH 80
+  [VDP_SCREEN_MODE_GRAPHIC_3]   = { .r0 = 0x04, .r1 = 0x00, .sprite_mode = 2 }, // SCREEN 4
+  [VDP_SCREEN_MODE_GRAPHIC_4]   = { .r0 = 0x06, .r1 = 0x00, .sprite_mode = 2 }, // SCREEN 5
+  [VDP_SCREEN_MODE_GRAPHIC_5]   = { .r0 = 0x08, .r1 = 0x00, .sprite_mode = 2 }, // SCREEN 6
+  [VDP_SCREEN_MODE_GRAPHIC_6]   = { .r0 = 0x0a, .r1 = 0x00, .sprite_mode = 2 }, // SCREEN 7
+  [VDP_SCREEN_MODE_GRAPHIC_7]   = { .r0 = 0x0e, .r1 = 0x00, .sprite_mode = 2 }, // SCREEN 8, 10, 11, or 12
+};
+
 void vdp_set_screen_mode(enum vdp_screen_mode mode) {
-  uint8_t r0;                   /* 0| 0| 0| 0|M5|M4|M3| 0 */
-  uint8_t r1;                   /* 0| 0| 0|M1|M2| 0| 0| 0 */
-  switch (mode) {
-    case VDP_SCREEN_MODE_TEXT_1:
-      r0 = 0x00; r1 = 0x10;
-      sprite_mode = 0;
-      break;
-    case VDP_SCREEN_MODE_TEXT_2:
-      r0 = 0x04; r1 = 0x10;
-      sprite_mode = 0;
-      break;
-    case VDP_SCREEN_MODE_MULTI_COLOR:
-      r0 = 0x00; r1 = 0x08;
-      sprite_mode = 1;
-      break;
-    case VDP_SCREEN_MODE_GRAPHIC_1:
-      r0 = 0x00; r1 = 0x00;
-      sprite_mode = 1;
-      break;
-    case VDP_SCREEN_MODE_GRAPHIC_2:
-      r0 = 0x02; r1 = 0x00;
-      sprite_mode = 1;
-      break;
-    case VDP_SCREEN_MODE_GRAPHIC_3:
-      r0 = 0x04; r1 = 0x00;
-      sprite_mode = 2;
-      break;
-    case VDP_SCREEN_MODE_GRAPHIC_4:
-      r0 = 0x06; r1 = 0x00;
-      sprite_mode = 2;
-      break;
-    case VDP_SCREEN_MODE_GRAPHIC_5:
-      r0 = 0x08; r1 = 0x00;
-      sprite_mode = 2;
-      break;
-    case VDP_SCREEN_MODE_GRAPHIC_6:
-      r0 = 0x0A; r1 = 0x00;
-      sprite_mode = 2;
-      break;
-    case VDP_SCREEN_MODE_GRAPHIC_7:
-      r0 = 0x0E; r1 = 0x00;
-      sprite_mode = 2;
-      break;
-    default:
-      return;
-  }
+  const struct screen_mode_vec * p = &screen_mode_vecs[mode];
   __asm__("di");
   screen_mode = mode;
-  RG0SAV = (RG0SAV & ~0x0e) | r0;
-  RG1SAV = (RG1SAV & ~0x18) | r1;
+  sprite_mode = p->sprite_mode;
+  RG0SAV = (RG0SAV & ~0x0e) | p->r0;
+  RG1SAV = (RG1SAV & ~0x18) | p->r1;
   VDP_SET_CONTROL_REGISTER(0, RG0SAV);
   VDP_SET_CONTROL_REGISTER(1, RG1SAV);
   __asm__("ei");

--- a/src/vdp_set_screen_mode.c
+++ b/src/vdp_set_screen_mode.c
@@ -24,7 +24,7 @@ void vdp_set_screen_mode(enum vdp_screen_mode mode) {
       sprite_mode = 0;
       break;
     case VDP_SCREEN_MODE_TEXT_2:
-      r0 = 0x08; r1 = 0x10;
+      r0 = 0x04; r1 = 0x10;
       sprite_mode = 0;
       break;
     case VDP_SCREEN_MODE_MULTI_COLOR:


### PR DESCRIPTION
- fix: `vdp_set_screen_mode()` : wrong register value for TEXT 2 mode.
- fix: `vdp_get_status()` : incompatibility issue.
- fix: `screen_mode`, `sprite_mode`: invalid combination of initial values.
- fix: `vdp_write_control()`: it's for `MSX2` or later. (typo of docs)
- refactoring and documentation.
