### PR TITLE
Feat(screen)/msx2 screen mode

### DIFF
--- a/include/screen.h
+++ b/include/screen.h
@@ -13,11 +13,17 @@
  * \brief SCREEN mode initialization function like MSX-BASIC.
  *
  * Functions corresponding to MSX-BASIC's following SCREEN modes:
- * - screen0()     : `SCREEN 0: WIDTH 40` (TEXT 1 mdoe),
- * - screen0_W80() : `SCREEN 0: WIDTH 80` (TEXT 2 mode) `MSX2` or later,
- * - screen1()     : `SCREEN 1: WIDTH 32` (GRAPHIC 1 mode),
- * - screen2()     : `SCREEN 2: WIDTH 32` (GRAPHIC 2 mode),
- * - screen2_PCG() : `SCREEN 2: WIDTH 32` (GRAPHIC 2 mode; PCG mode like as SCREEN 1).
+ * - `MSX`  screen0()     : `SCREEN 0: WIDTH 40` (TEXT 1 mdoe),
+ * - `MSX`  screen1()     : `SCREEN 1: WIDTH 32` (GRAPHIC 1 mode),
+ * - `MSX`  screen2()     : `SCREEN 2: WIDTH 32` (GRAPHIC 2 mode),
+ * - `MSX`  screen2_PCG() : `SCREEN 2: WIDTH 32` (GRAPHIC 2 mode; PCG mode like as SCREEN 1).
+ * - `MSX2` screen0_W80() : `SCREEN 0: WIDTH 80` (TEXT 2 mode),
+ * - `MSX2` screen4()     : `SCREEN 4: WIDTH 32` (GRAPHIC 3 mode),
+ * - `MSX2` screen4_PCG() : `SCREEN 4: WIDTH 32` (GRAPHIC 3 mode; PCG mode like as SCREEN 1).
+ * - `MSX2` screen5()     : `SCREEN 5`           (GRAPHIC 4 mode; 256x212 pix, 4-bpp),
+ * - `MSX2` screen6()     : `SCREEN 6`           (GRAPHIC 5 mode; 512x212 pix, 2-bpp),
+ * - `MSX2` screen7()     : `SCREEN 7`           (GRAPHIC 6 mode; 512x212 pix, 4-bpp),
+ * - `MSX2` screen8()     : `SCREEN 8`           (GRAPHIC 7 mode; 256x212 pix, 8-bpp),
  *
  * **All** above SCREEN modes supports:
  * - printf() and putchar() standard C library functions (`#include <stdio.h>`), and
@@ -34,6 +40,9 @@
 /**
  * `MSX` SCREEN 0: WIDTH 40 (TEXT 1 mode).
  *
+ * - 40 columns x 24 lines text mode.
+ * - No sprites.
+ *
  * **VRAM memory map**
  * | VRAM address | size   | contents                        |
  * |--------------|--------|---------------------------------|
@@ -48,6 +57,9 @@ void screen0(void);
 
 /**
  * `MSX` SCREEN 1: WIDTH 32 (GRAPHIC 1 mode).
+ *
+ * - 32 columns x 24 lines tiled graphics mode.
+ * - Sprite mode 1.
  *
  * **VRAM memory map**
  * | VRAM address | size   | contents                        |
@@ -70,6 +82,9 @@ void screen1(void);
 
 /**
  * `MSX` SCREEN 2: WIDTH 32 (GRAPHIC 2 mode).
+ *
+ * - 32 columns x 24 lines tiled graphics mode.
+ * - Sprite mode 1.
  *
  * **VRAM memory map**
  * | VRAM address | size   | contents                        |
@@ -104,6 +119,9 @@ void screen2(void);
 /**
  * `MSX` SCREEN 2: WIDTH 32 (GRAPHIC 2 mode; PCG mode like as SCREEN 1).
  *
+ * - 32 columns x 24 lines tiled graphics mode.
+ * - Sprite mode 1.
+ *
  * **VRAM memory map**
  * | VRAM address | size   | contents                        |
  * |--------------|--------|---------------------------------|
@@ -125,6 +143,9 @@ void screen2_PCG(void);
 /**
  * `MSX2` SCREEN 0: WIDTH 80 (TEXT 2 mode).
  *
+ * - 80 columns x 24 lines text mode.
+ * - No sprites.
+ *
  * **VRAM memory map**
  * | VRAM address | size   | contents                        |
  * |--------------|--------|---------------------------------|
@@ -141,5 +162,149 @@ void screen2_PCG(void);
  * table** in VRAM).
  */
 void screen0_W80(void);
+
+/**
+ * `MSX2` SCREEN 4: WIDTH 32 (GRAPHIC 3 mode).
+ *
+ * - 32 columns x 24 lines tiled graphics mode.
+ * - Sprite mode 2.
+ *
+ * **VRAM memory map**
+ * | VRAM address | size   | contents                        |
+ * |--------------|--------|---------------------------------|
+ * | 0x00000      | 0x1800 | Pattern generator table         |
+ * | 0x01800      | 0x0300 | Pattern name table              |
+ * | 0x01C00      | 0x0200 | Sprite color table              |
+ * | 0x01E00      | 0x0080 | Sprite attribute table          |
+ * | 0x02000      | 0x1800 | Color table                     |
+ * | 0x03800      | 0x0300 | Sprite pattern generator table  |
+ *
+ * The **pattern name table** is initialized as follows and will not be changed
+ * thereafter:
+ * ~~~ c
+ * uint8_t pattern_name_table[0x0300] = {
+ *   0x00, 0x01, ..., 0xff,  // (0, 0) .. (31, 7) ; top of screen
+ *   0x00, 0x01, ..., 0xff,  // (0, 8) .. (31,15) ; middle of screen
+ *   0x00, 0x01, ..., 0xff,  // (0,16) .. (31,23) ; bottom of screen
+ * };
+ * ~~~
+ *
+ * The **pattern generator table** and **color table** are then used as the
+ * canvas for the graphics screen. Thus, the characters in the text are also
+ * drawn as images one by one. Thus, the text will be more colorful, but a
+ * little slower.
+ *
+ * \note
+ * In this mode, text is drawn as individual color text.
+ * (i.e., text is drawn as a two-tone color graphic).
+ */
+void screen4(void);
+
+/**
+ * `MSX2` SCREEN 4: WIDTH 32 (GRAPHIC 3 mode; PCG mode like as SCREEN 1).
+ *
+ * - 32 columns x 24 lines tiled graphics mode.
+ * - Sprite mode 2.
+ *
+ * **VRAM memory map**
+ * | VRAM address | size   | contents                        |
+ * |--------------|--------|---------------------------------|
+ * | 0x00000      | 0x1800 | Pattern generator table         |
+ * | 0x01800      | 0x0300 | Pattern name table              |
+ * | 0x01C00      | 0x0200 | Sprite color table              |
+ * | 0x01E00      | 0x0080 | Sprite attribute table          |
+ * | 0x02000      | 0x1800 | Color table                     |
+ * | 0x03800      | 0x0300 | Sprite pattern generator table  |
+ *
+ * \note
+ * For each 256-character font, three patterns/colors can be defined for the
+ * top, middle, and bottom of the screen (**pattern generator table** and
+ * **color table** in VRAM).
+ */
+void screen4_PCG(void);
+
+/**
+ * `MSX2` SCREEN 5 (GRAPHIC 4 mode).
+ *
+ * - 256 x 212 pixel, 4-bpp graphics mode.
+ * - 16 colors/pixel of 512 colors (RGB333).
+ * - Sprite mode 2.
+ *
+ * **VRAM memory map**
+ * | VRAM address | size   | contents                        |
+ * |--------------|--------|---------------------------------|
+ * | 0x00000      | 0x6A00 | Pattern name table              |
+ * | 0x07400      | 0x0200 | Sprite color table              |
+ * | 0x07600      | 0x0080 | Sprite attribute table          |
+ * | 0x07800      | 0x0300 | Sprite pattern generator table  |
+ *
+ * \note
+ * In this mode, text is drawn as individual color text.
+ * (i.e., text is drawn as a two-tone color graphic).
+ */
+void screen5(void);
+
+/**
+ * `MSX2` SCREEN 6 (GRAPHIC 5 mode).
+ *
+ * - 256 x 212 pixel, 2-bpp graphics mode.
+ * - 4 colors/pixel of 512 colors (RGB333).
+ * - Sprite mode 2.
+ *
+ * **VRAM memory map**
+ * | VRAM address | size   | contents                        |
+ * |--------------|--------|---------------------------------|
+ * | 0x00000      | 0x6A00 | Pattern name table              |
+ * | 0x07400      | 0x0200 | Sprite color table              |
+ * | 0x07600      | 0x0080 | Sprite attribute table          |
+ * | 0x07800      | 0x0300 | Sprite pattern generator table  |
+ *
+ * \note
+ * In this mode, text is drawn as individual color text.
+ * (i.e., text is drawn as a two-tone color graphic).
+ */
+void screen6(void);
+
+/**
+ * `MSX2` SCREEN 7 (GRAPHIC 6 mode).
+ *
+ * - 512 x 212 pixels, 4-bpp graphics mode.
+ * - 16 colors/pixel of 512 colors (RGB333).
+ * - Sprite mode 2.
+ *
+ * **VRAM memory map**
+ * | VRAM address | size   | contents                        |
+ * |--------------|--------|---------------------------------|
+ * | 0x00000      | 0xD400 | Pattern name table              |
+ * | 0x0F000      | 0x0300 | Sprite pattern generator table  |
+ * | 0x0F800      | 0x0200 | Sprite color table              |
+ * | 0x0FA00      | 0x0080 | Sprite attribute table          |
+ *
+ * \note
+ * In this mode, text is drawn as individual color text.
+ * (i.e., text is drawn as a two-tone color graphic).
+ */
+void screen7(void);
+
+/**
+ * `MSX2` SCREEN 8 (GRAPHIC 7 mode).
+ *
+ * - 256 x 212 pixel, 8-bpp graphics mode.
+ * - 256 colors/pixel of 256 colors (RGB332).
+ * - Sprite mode 2.
+ *
+ * **VRAM memory map**
+ * | VRAM address | size   | contents                        |
+ * |--------------|--------|---------------------------------|
+ * | 0x00000      | 0xD400 | Pattern name table              |
+ * | 0x0F000      | 0x0300 | Sprite pattern generator table  |
+ * | 0x0F800      | 0x0200 | Sprite color table              |
+ * | 0x0FA00      | 0x0080 | Sprite attribute table          |
+ *
+ * \note
+ * In this mode, text is drawn as individual color text.
+ * (i.e., text is drawn as a two-tone color graphic).
+ */
+void screen8(void);
 
 #endif // SCREEN_H_

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -93,4 +93,24 @@ void vmem_set_sprite(vmemptr_t base, uint8_t plane, const struct sprite* s) {
   vmem_write(base + plane * sizeof(struct sprite), (void*)s, sizeof(struct sprite));
 }
 
+/**
+ * `MSX` Initialize the sprite attribute table.
+ *
+ * Same as the following code:
+ * ~~~ c
+ * for (uint8_t plane = 0; plane < 32; plane++) {
+ *   struct sprite s = {
+ *     .y = 217,
+ *     .x = 0,
+ *     .pat = plane,
+ *     .tagged_color = 0,
+ *   };
+ *   vmem_set_sprite(base, plane, &s);
+ * }
+ * ~~~
+ *
+ * \param base  Base address of the SPRITE ATTRIBUTE TABLE in VRAM.
+ */
+void vmem_init_sprites(vmemptr_t base);
+
 #endif

--- a/src/screen1.c
+++ b/src/screen1.c
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include <vdp.h>
 #include <vmem.h>
+#include <sprite.h>
 
 /* Configurations for GRAPHIC 1 mode (SCREEN 1) */
 #define SCREEN_MODE     VDP_SCREEN_MODE_GRAPHIC_1
@@ -76,6 +77,7 @@ void screen1(void) {
 
   vdp_set_sprite_attribute_table(SPRITES);
   vdp_set_sprite_pattern_table(SPRITE_PATTERNS);
+  vmem_init_sprites(SPRITES);
 
   // Copy MSX fonts into VRAM
   vmem_write(PATTERNS, (void *)CGTBL, 8*256);

--- a/src/screen2.c
+++ b/src/screen2.c
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include <vdp.h>
 #include <vmem.h>
+#include <sprite.h>
 
 /* Configurations for GRAPHIC 2 mode (SCREEN 2) */
 #define SCREEN_MODE     VDP_SCREEN_MODE_GRAPHIC_2
@@ -76,6 +77,7 @@ void screen2(void) {
 
   vdp_set_sprite_attribute_table(SPRITES);
   vdp_set_sprite_pattern_table(SPRITE_PATTERNS);
+  vmem_init_sprites(SPRITES);
 
   vmem_set_write_address(IMAGE);
   for (int c = 0; c < 768; c++) {

--- a/src/screen2_PCG.c
+++ b/src/screen2_PCG.c
@@ -9,7 +9,7 @@
  * https://github.com/mori0091/libmsx
  */
 /**
- * \file screen2.c
+ * \file screen2_PCG.c
  */
 
 #include "screen.h"
@@ -60,6 +60,10 @@ static const struct TTY_Device dev = {
 };
 
 void screen2_PCG(void) {
+  if (msx_get_version()) {
+    vdp_set_screen_lines(VDP_SCREEN_LINES_192);
+  }
+
   /* zero clear 16KiB VRAM */
   vmem_memset(0, 0, 16384);
 

--- a/src/screen2_PCG.c
+++ b/src/screen2_PCG.c
@@ -17,6 +17,7 @@
 #include "tty.h"
 #include <vdp.h>
 #include <vmem.h>
+#include <sprite.h>
 
 /* Configurations for GRAPHIC 2 mode (SCREEN 2) */
 #define SCREEN_MODE     VDP_SCREEN_MODE_GRAPHIC_2
@@ -75,6 +76,7 @@ void screen2_PCG(void) {
 
   vdp_set_sprite_attribute_table(SPRITES);
   vdp_set_sprite_pattern_table(SPRITE_PATTERNS);
+  vmem_init_sprites(SPRITES);
 
   // Copy MSX fonts into VRAM
   vmem_write(PATTERNS+0x0000, (void *)CGTBL, 0x0800);

--- a/src/screen4.c
+++ b/src/screen4.c
@@ -1,0 +1,86 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2021-2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file screen4.c
+ */
+
+#include "screen.h"
+
+#include "tty.h"
+#include <stdint.h>
+#include <vdp.h>
+#include <vmem.h>
+
+/* Configurations for GRAPHIC 3 mode (SCREEN 4) */
+#define SCREEN_MODE     VDP_SCREEN_MODE_GRAPHIC_3
+#define PATTERNS        (0x00000) // pattern generator table
+#define IMAGE           (0x01800) // pattern name table
+#define COLORS          (0x02000) // color table
+#define SPRITES         (0x01E00) // sprite attribute table
+#define SPRITE_PATTERNS (0x03800) // sprite pattern generator table
+#define SIZE_OF_PATTERNS (0x1800) // size of pattern generator table
+#define SIZE_OF_IMAGE    (0x0300) // size of pattern name table
+#define SIZE_OF_COLORS   (0x1800) // size of color table
+
+#define COLUMNS (32)
+#define LINES   (24)
+#define POS     ((COLUMNS * CSRY + CSRX) * 8)
+
+#define TEXT_COLOR       (((FORCLR & 15) << 4) | (BAKCLR & 15))
+
+static void clear_screen(void) {
+  vmem_memset(PATTERNS, 0, SIZE_OF_PATTERNS);
+  vmem_memset(COLORS, TEXT_COLOR, SIZE_OF_COLORS);
+}
+
+static void render_char(uint8_t c) {
+  vmem_write(PATTERNS + POS, (void *)&CGTBL->data[c][0], 8);
+  vmem_memset(COLORS + POS, TEXT_COLOR, 8);
+}
+
+static void set_border_color(uint8_t border) {
+  /* Set backdrop color (border color of the screen) */
+  vdp_set_color(border & 15);
+}
+
+static const struct TTY_Device dev = {
+  .columns = COLUMNS,
+  .lines = LINES,
+  .clear_screen = clear_screen,
+  .render_char = render_char,
+  .set_text_color = 0,
+  .set_border_color = set_border_color,
+};
+
+void screen4(void) {
+  vdp_set_screen_lines(VDP_SCREEN_LINES_192);
+
+  /* zero clear 16KiB VRAM */
+  vmem_memset(0, 0, 16384);
+
+  vdp_set_screen_mode(SCREEN_MODE);
+
+  vdp_set_image_table(IMAGE);
+  vdp_set_pattern_table(PATTERNS);
+  vdp_set_color_table(COLORS);
+
+  vdp_set_sprite_attribute_table(SPRITES);
+  vdp_set_sprite_pattern_table(SPRITE_PATTERNS);
+
+  vmem_set_write_address(IMAGE);
+  for (int c = 0; c < 768; c++) {
+    vmem_set(c & 255);
+  }
+
+  TTY_device = &dev;
+  TTY_set_color(FORCLR, BAKCLR, BDRCLR);
+  TTY_cls();
+}

--- a/src/screen4.c
+++ b/src/screen4.c
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include <vdp.h>
 #include <vmem.h>
+#include <sprite.h>
 
 /* Configurations for GRAPHIC 3 mode (SCREEN 4) */
 #define SCREEN_MODE     VDP_SCREEN_MODE_GRAPHIC_3
@@ -74,6 +75,7 @@ void screen4(void) {
 
   vdp_set_sprite_attribute_table(SPRITES);
   vdp_set_sprite_pattern_table(SPRITE_PATTERNS);
+  vmem_init_sprites(SPRITES);
 
   vmem_set_write_address(IMAGE);
   for (int c = 0; c < 768; c++) {

--- a/src/screen4_PCG.c
+++ b/src/screen4_PCG.c
@@ -1,0 +1,85 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2021-2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file screen4_PCG.c
+ */
+
+#include "screen.h"
+
+#include "tty.h"
+#include <vdp.h>
+#include <vmem.h>
+
+/* Configurations for GRAPHIC 3 mode (SCREEN 4) */
+#define SCREEN_MODE     VDP_SCREEN_MODE_GRAPHIC_3
+#define PATTERNS        (0x00000) // pattern generator table
+#define IMAGE           (0x01800) // pattern name table
+#define COLORS          (0x02000) // color table
+#define SPRITES         (0x01E00) // sprite attribute table
+#define SPRITE_PATTERNS (0x03800) // sprite pattern generator table
+#define SIZE_OF_PATTERNS (0x1800) // size of pattern generator table
+#define SIZE_OF_IMAGE    (0x0300) // size of pattern name table
+#define SIZE_OF_COLORS   (0x1800) // size of color table
+
+#define COLUMNS (32)
+#define LINES   (24)
+#define POS     (COLUMNS * CSRY + CSRX)
+
+static void clear_screen(void) {
+  vmem_memset(IMAGE, ' ', SIZE_OF_IMAGE);
+}
+
+static void render_char(uint8_t c) {
+  vmem_write(IMAGE + POS, (void *)&c, 1);
+}
+
+static void set_text_color(uint8_t fg, uint8_t bg) {
+  /* Set foreground and background color */
+  vmem_memset(COLORS, ((fg & 15) << 4) | (bg & 15), SIZE_OF_COLORS);
+}
+static void set_border_color(uint8_t border) {
+  /* Set backdrop color (border color of the screen) */
+  vdp_set_color(border & 15);
+}
+
+static const struct TTY_Device dev = {
+  .columns = COLUMNS,
+  .lines = LINES,
+  .clear_screen = clear_screen,
+  .render_char = render_char,
+  .set_text_color = set_text_color,
+  .set_border_color = set_border_color,
+};
+
+void screen4_PCG(void) {
+  vdp_set_screen_lines(VDP_SCREEN_LINES_192);
+
+  /* zero clear 16KiB VRAM */
+  vmem_memset(0, 0, 16384);
+
+  vdp_set_screen_mode(SCREEN_MODE);
+
+  vdp_set_image_table(IMAGE);
+  vdp_set_pattern_table(PATTERNS);
+  vdp_set_color_table(COLORS);
+
+  vdp_set_sprite_attribute_table(SPRITES);
+  vdp_set_sprite_pattern_table(SPRITE_PATTERNS);
+
+  // Copy MSX fonts into VRAM
+  vmem_write(PATTERNS+0x0000, (void *)CGTBL, 0x0800);
+  vmem_write(PATTERNS+0x0800, (void *)CGTBL, 0x0800);
+  vmem_write(PATTERNS+0x1000, (void *)CGTBL, 0x0800);
+
+  TTY_device = &dev;
+  TTY_set_color(FORCLR, BAKCLR, BDRCLR);
+  TTY_cls();
+}

--- a/src/screen4_PCG.c
+++ b/src/screen4_PCG.c
@@ -17,6 +17,7 @@
 #include "tty.h"
 #include <vdp.h>
 #include <vmem.h>
+#include <sprite.h>
 
 /* Configurations for GRAPHIC 3 mode (SCREEN 4) */
 #define SCREEN_MODE     VDP_SCREEN_MODE_GRAPHIC_3
@@ -73,6 +74,7 @@ void screen4_PCG(void) {
 
   vdp_set_sprite_attribute_table(SPRITES);
   vdp_set_sprite_pattern_table(SPRITE_PATTERNS);
+  vmem_init_sprites(SPRITES);
 
   // Copy MSX fonts into VRAM
   vmem_write(PATTERNS+0x0000, (void *)CGTBL, 0x0800);

--- a/src/screen5.c
+++ b/src/screen5.c
@@ -38,6 +38,7 @@
 
 static void clear_screen(void) {
   vdp_cmd_execute_HMMV(0, 0, WIDTH, HEIGHT, ((BAKCLR & 15) << 4) | (BAKCLR & 15));
+  vdp_cmd_await();
 }
 
 static void render_char(uint8_t c) {

--- a/src/screen5.c
+++ b/src/screen5.c
@@ -1,0 +1,89 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2021-2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file screen5.c
+ */
+
+#include "screen.h"
+
+#include "tty.h"
+#include <stdint.h>
+#include <vdp.h>
+#include <vmem.h>
+#include <sprite.h>
+
+/* Configurations for GRAPHIC 4 mode (SCREEN 5) */
+#define SCREEN_MODE     VDP_SCREEN_MODE_GRAPHIC_4
+#define IMAGE           (0x00000) // pattern name table
+#define SPRITES         (0x07600) // sprite attribute table
+#define SPRITE_PATTERNS (0x07800) // sprite pattern generator table
+#define SIZE_OF_IMAGE    (0x6A00) // size of pattern name table
+
+#define WIDTH           (256)             // number of pixels per line
+#define HEIGHT          (212)             // number of lines
+#define BPP             (4)               // nuber of bits per pixel
+#define BYTES_PER_LINE  (WIDTH * BPP / 8) // number of bytes per line
+
+#define COLUMNS (32)
+#define LINES   (26)
+#define POS     ((vmemptr_t)BYTES_PER_LINE * 8 * CSRY + BPP * CSRX)
+
+static void clear_screen(void) {
+  vdp_cmd_execute_HMMV(0, 0, WIDTH, HEIGHT, ((BAKCLR & 15) << 4) | (BAKCLR & 15));
+}
+
+static void render_char(uint8_t c) {
+  vmemptr_t dst = IMAGE + POS;
+  const uint8_t * p = &CGTBL->data[c][0];
+  for (uint8_t n = 8; n--; ) {
+    vmem_set_write_address(dst);
+    dst += BYTES_PER_LINE;
+    uint8_t bits = *p++;
+    for (uint8_t i = 4; i--; ) {
+      uint8_t c
+        = (((bits & 0x80) ? FORCLR : BAKCLR) << 4)
+        | (((bits & 0x40) ? FORCLR : BAKCLR) & 15);
+      vmem_set(c);
+      bits <<= 2;
+    }
+  }
+}
+
+static void set_border_color(uint8_t border) {
+  /* Set backdrop color (border color of the screen) */
+  vdp_set_color(border & 15);
+}
+
+static const struct TTY_Device dev = {
+  .columns = COLUMNS,
+  .lines = LINES,
+  .clear_screen = clear_screen,
+  .render_char = render_char,
+  .set_text_color = 0,
+  .set_border_color = set_border_color,
+};
+
+void screen5(void) {
+  vdp_set_screen_lines(VDP_SCREEN_LINES_212);
+
+  vdp_set_screen_mode(SCREEN_MODE);
+
+  vdp_set_image_table(IMAGE);
+
+  vdp_set_sprite_attribute_table(SPRITES);
+  vdp_set_sprite_pattern_table(SPRITE_PATTERNS);
+
+  vmem_init_sprites(SPRITES);
+
+  TTY_device = &dev;
+  TTY_set_color(FORCLR, BAKCLR, BDRCLR);
+  TTY_cls();
+}

--- a/src/screen6.c
+++ b/src/screen6.c
@@ -1,0 +1,92 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2021-2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file screen6.c
+ */
+
+#include "screen.h"
+
+#include "tty.h"
+#include <stdint.h>
+#include <vdp.h>
+#include <vmem.h>
+#include <sprite.h>
+
+/* Configurations for GRAPHIC 5 mode (SCREEN 6) */
+#define SCREEN_MODE     VDP_SCREEN_MODE_GRAPHIC_5
+#define IMAGE           (0x00000) // pattern name table
+#define SPRITES         (0x07600) // sprite attribute table
+#define SPRITE_PATTERNS (0x07800) // sprite pattern generator table
+#define SIZE_OF_IMAGE    (0x6A00) // size of pattern name table
+
+#define WIDTH           (512)             // number of pixels per line
+#define HEIGHT          (212)             // number of lines
+#define BPP             (2)               // nuber of bits per pixel
+#define BYTES_PER_LINE  (WIDTH * BPP / 8) // number of bytes per line
+
+#define COLUMNS (64)
+#define LINES   (26)
+#define POS     ((vmemptr_t)BYTES_PER_LINE * 8 * CSRY + BPP * CSRX)
+
+static void clear_screen(void) {
+  uint8_t c = (BAKCLR & 3) * 0x55;
+  vdp_cmd_execute_HMMV(0, 0, WIDTH, HEIGHT, c);
+}
+
+static void render_char(uint8_t c) {
+  vmemptr_t dst = IMAGE + POS;
+  const uint8_t * p = &CGTBL->data[c][0];
+  for (uint8_t n = 8; n--; ) {
+    vmem_set_write_address(dst);
+    dst += BYTES_PER_LINE;
+    uint8_t bits = *p++;
+    for (uint8_t i = 2; i--; ) {
+      uint8_t c
+        = ((((bits & 0x80) ? FORCLR : BAKCLR) & 3) << 6)
+        | ((((bits & 0x40) ? FORCLR : BAKCLR) & 3) << 4)
+        | ((((bits & 0x20) ? FORCLR : BAKCLR) & 3) << 2)
+        | ((((bits & 0x10) ? FORCLR : BAKCLR) & 3) << 0);
+      vmem_set(c);
+      bits <<= 4;
+    }
+  }
+}
+
+static void set_border_color(uint8_t border) {
+  /* Set backdrop color (border color of the screen) */
+  vdp_set_color(border & 15);
+}
+
+static const struct TTY_Device dev = {
+  .columns = COLUMNS,
+  .lines = LINES,
+  .clear_screen = clear_screen,
+  .render_char = render_char,
+  .set_text_color = 0,
+  .set_border_color = set_border_color,
+};
+
+void screen6(void) {
+  vdp_set_screen_lines(VDP_SCREEN_LINES_212);
+
+  vdp_set_screen_mode(SCREEN_MODE);
+
+  vdp_set_image_table(IMAGE);
+
+  vdp_set_sprite_attribute_table(SPRITES);
+  vdp_set_sprite_pattern_table(SPRITE_PATTERNS);
+
+  vmem_init_sprites(SPRITES);
+
+  TTY_device = &dev;
+  TTY_set_color(FORCLR, BAKCLR, BDRCLR);
+  TTY_cls();
+}

--- a/src/screen6.c
+++ b/src/screen6.c
@@ -39,6 +39,7 @@
 static void clear_screen(void) {
   uint8_t c = (BAKCLR & 3) * 0x55;
   vdp_cmd_execute_HMMV(0, 0, WIDTH, HEIGHT, c);
+  vdp_cmd_await();
 }
 
 static void render_char(uint8_t c) {

--- a/src/screen6.c
+++ b/src/screen6.c
@@ -62,7 +62,7 @@ static void render_char(uint8_t c) {
 
 static void set_border_color(uint8_t border) {
   /* Set backdrop color (border color of the screen) */
-  vdp_set_color(border & 15);
+  vdp_set_color((border & 3) * 0x55);
 }
 
 static const struct TTY_Device dev = {

--- a/src/screen7.c
+++ b/src/screen7.c
@@ -38,6 +38,7 @@
 
 static void clear_screen(void) {
   vdp_cmd_execute_HMMV(0, 0, WIDTH, HEIGHT, ((BAKCLR & 15) << 4) | (BAKCLR & 15));
+  vdp_cmd_await();
 }
 
 static void render_char(uint8_t c) {

--- a/src/screen7.c
+++ b/src/screen7.c
@@ -1,0 +1,89 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2021-2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file screen7.c
+ */
+
+#include "screen.h"
+
+#include "tty.h"
+#include <stdint.h>
+#include <vdp.h>
+#include <vmem.h>
+#include <sprite.h>
+
+/* Configurations for GRAPHIC 6 mode (SCREEN 7) */
+#define SCREEN_MODE     VDP_SCREEN_MODE_GRAPHIC_6
+#define IMAGE           (0x00000) // pattern name table
+#define SPRITES         (0x0FA00) // sprite attribute table
+#define SPRITE_PATTERNS (0x0F000) // sprite pattern generator table
+#define SIZE_OF_IMAGE    (0xD400) // size of pattern name table
+
+#define WIDTH           (512)             // number of pixels per line
+#define HEIGHT          (212)             // number of lines
+#define BPP             (4)               // nuber of bits per pixel
+#define BYTES_PER_LINE  (WIDTH * BPP / 8) // number of bytes per line
+
+#define COLUMNS (64)
+#define LINES   (26)
+#define POS     ((vmemptr_t)BYTES_PER_LINE * 8 * CSRY + BPP * CSRX)
+
+static void clear_screen(void) {
+  vdp_cmd_execute_HMMV(0, 0, WIDTH, HEIGHT, ((BAKCLR & 15) << 4) | (BAKCLR & 15));
+}
+
+static void render_char(uint8_t c) {
+  vmemptr_t dst = IMAGE + POS;
+  const uint8_t * p = &CGTBL->data[c][0];
+  for (uint8_t n = 8; n--; ) {
+    vmem_set_write_address(dst);
+    dst += BYTES_PER_LINE;
+    uint8_t bits = *p++;
+    for (uint8_t i = 4; i--; ) {
+      uint8_t c
+        = (((bits & 0x80) ? FORCLR : BAKCLR) << 4)
+        | (((bits & 0x40) ? FORCLR : BAKCLR) & 15);
+      vmem_set(c);
+      bits <<= 2;
+    }
+  }
+}
+
+static void set_border_color(uint8_t border) {
+  /* Set backdrop color (border color of the screen) */
+  vdp_set_color(border & 15);
+}
+
+static const struct TTY_Device dev = {
+  .columns = COLUMNS,
+  .lines = LINES,
+  .clear_screen = clear_screen,
+  .render_char = render_char,
+  .set_text_color = 0,
+  .set_border_color = set_border_color,
+};
+
+void screen7(void) {
+  vdp_set_screen_lines(VDP_SCREEN_LINES_212);
+
+  vdp_set_screen_mode(SCREEN_MODE);
+
+  vdp_set_image_table(IMAGE);
+
+  vdp_set_sprite_attribute_table(SPRITES);
+  vdp_set_sprite_pattern_table(SPRITE_PATTERNS);
+
+  vmem_init_sprites(SPRITES);
+
+  TTY_device = &dev;
+  TTY_set_color(FORCLR, BAKCLR, BDRCLR);
+  TTY_cls();
+}

--- a/src/screen8.c
+++ b/src/screen8.c
@@ -1,0 +1,88 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2021-2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file screen8.c
+ */
+
+#include "screen.h"
+
+#include "tty.h"
+#include <stdint.h>
+#include <vdp.h>
+#include <vmem.h>
+#include <sprite.h>
+
+/* Configurations for GRAPHIC 7 mode (SCREEN 8) */
+#define SCREEN_MODE     VDP_SCREEN_MODE_GRAPHIC_7
+#define IMAGE           (0x00000) // pattern name table
+#define SPRITES         (0x0FA00) // sprite attribute table
+#define SPRITE_PATTERNS (0x0F000) // sprite pattern generator table
+#define SIZE_OF_IMAGE    (0xD400) // size of pattern name table
+
+#define WIDTH           (256)             // number of pixels per line
+#define HEIGHT          (212)             // number of lines
+#define BPP             (8)               // nuber of bits per pixel
+#define BYTES_PER_LINE  (WIDTH * BPP / 8) // number of bytes per line
+
+#define COLUMNS (32)
+#define LINES   (26)
+#define POS     ((vmemptr_t)BYTES_PER_LINE * 8 * CSRY + BPP * CSRX)
+
+static void clear_screen(void) {
+  vdp_cmd_execute_HMMV(0, 0, WIDTH, HEIGHT, BAKCLR);
+  vdp_cmd_await();
+}
+
+static void render_char(uint8_t c) {
+  vmemptr_t dst = IMAGE + POS;
+  const uint8_t * p = &CGTBL->data[c][0];
+  for (uint8_t n = 8; n--; ) {
+    vmem_set_write_address(dst);
+    dst += BYTES_PER_LINE;
+    uint8_t bits = *p++;
+    for (uint8_t i = 8; i--; ) {
+      uint8_t c = ((bits & 0x80) ? FORCLR : BAKCLR);
+      vmem_set(c);
+      bits <<= 1;
+    }
+  }
+}
+
+static void set_border_color(uint8_t border) {
+  /* Set backdrop color (border color of the screen) */
+  vdp_set_color(border);
+}
+
+static const struct TTY_Device dev = {
+  .columns = COLUMNS,
+  .lines = LINES,
+  .clear_screen = clear_screen,
+  .render_char = render_char,
+  .set_text_color = 0,
+  .set_border_color = set_border_color,
+};
+
+void screen8(void) {
+  vdp_set_screen_lines(VDP_SCREEN_LINES_212);
+
+  vdp_set_screen_mode(SCREEN_MODE);
+
+  vdp_set_image_table(IMAGE);
+
+  vdp_set_sprite_attribute_table(SPRITES);
+  vdp_set_sprite_pattern_table(SPRITE_PATTERNS);
+
+  vmem_init_sprites(SPRITES);
+
+  TTY_device = &dev;
+  TTY_set_color(FORCLR, BAKCLR, BDRCLR);
+  TTY_cls();
+}

--- a/src/vmem_init_sprites.c
+++ b/src/vmem_init_sprites.c
@@ -1,0 +1,25 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2021-2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file vmem_init_sprites.c
+ */
+
+#include <vmem.h>
+
+void vmem_init_sprites(const vmemptr_t base) {
+  vmem_set_write_address(base);
+  for (uint8_t n = 0; n < 32; n++) {
+    vmem_set(217);              // y
+    vmem_set(0);                // x
+    vmem_set(n);                // pat
+    vmem_set(0);                // tag | color
+  }
+}


### PR DESCRIPTION
added the following `MSX2` screen mode:
- `screen4()`
- `screen4_PCG()`
- `screen5()`
- `screen6()`
- `screen7()`
- `screen8()`
