### PR TITLE
feat!(bmem): Banked Memory interface for MegaROM

### DIFF
--- a/crt0/crt0_mod_rom_header/app_megarom_header.s
+++ b/crt0/crt0_mod_rom_header/app_megarom_header.s
@@ -2,10 +2,10 @@
 
 ;;; Copyright (c) 2021-2022 Daishi Mori (mori0091)
 ;;;
-;;; This software is released under the MIT License.
+;;; This software is released under the MIT License.\n
 ;;; See https://github.com/mori0091/libmsx/blob/main/LICENSE
 ;;;
-;;; GitHub libmsx project
+;;; GitHub libmsx project\n
 ;;; https://github.com/mori0091/libmsx
 
 ;;; \file crt0/rom_header/app_megarom_header.s
@@ -37,8 +37,6 @@
         .area   _GSINIT
         .area   _GSFINAL
         ;; ----
-        .area   _BANK0
-        ;; ----
         .area   _DATA
         .area   _INITIALIZED
         .area   _BSEG
@@ -51,3 +49,60 @@
         .area   _BANK4
         .area   _BANK5
         .area   _BANK6
+        .area   _BANK7
+        .area   _BANK8
+        .area   _BANK9
+        .area   _BANK10
+        .area   _BANK11
+        .area   _BANK12
+        .area   _BANK13
+        .area   _BANK14
+        .area   _BANK15
+        .area   _BANK16
+        .area   _BANK17
+        .area   _BANK18
+        .area   _BANK19
+        .area   _BANK20
+        .area   _BANK21
+        .area   _BANK22
+        .area   _BANK23
+        .area   _BANK24
+        .area   _BANK25
+        .area   _BANK26
+        .area   _BANK27
+        .area   _BANK28
+        .area   _BANK29
+        .area   _BANK30
+        .area   _BANK31
+        .area   _BANK32
+        .area   _BANK33
+        .area   _BANK34
+        .area   _BANK35
+        .area   _BANK36
+        .area   _BANK37
+        .area   _BANK38
+        .area   _BANK39
+        .area   _BANK40
+        .area   _BANK41
+        .area   _BANK42
+        .area   _BANK43
+        .area   _BANK44
+        .area   _BANK45
+        .area   _BANK46
+        .area   _BANK47
+        .area   _BANK48
+        .area   _BANK49
+        .area   _BANK50
+        .area   _BANK51
+        .area   _BANK52
+        .area   _BANK53
+        .area   _BANK54
+        .area   _BANK55
+        .area   _BANK56
+        .area   _BANK57
+        .area   _BANK58
+        .area   _BANK59
+        .area   _BANK60
+        .area   _BANK61
+        .area   _BANK62
+        .area   _BANK63

--- a/crt0/crt0_mod_rom_mapper/rom_ascii16.s
+++ b/crt0/crt0_mod_rom_mapper/rom_ascii16.s
@@ -4,10 +4,10 @@
 ;;;
 ;;; Copyright (c) 2021-2022 Daishi Mori (mori0091)
 ;;;
-;;; This software is released under the MIT License.
+;;; This software is released under the MIT License.\n
 ;;; See https://github.com/mori0091/libmsx/blob/main/LICENSE
 ;;;
-;;; GitHub libmsx project
+;;; GitHub libmsx project\n
 ;;; https://github.com/mori0091/libmsx
 
         .module crt0
@@ -21,15 +21,14 @@ rom_init::
         xor     a
         ld      (ROM_MAPPER_REGISTER_0), a ; segment #0
         inc     a
-        ld      (ROM_MAPPER_REGISTER_1), a ; segment #1 (bank #0)
+        ld      (ROM_MAPPER_REGISTER_1), a ; segment #1 (bank #1)
         ret
 
 ;------------------------------------------------
 set_bank::
         ld      (cur_bank), a
         ;; one 16KiB page per one bank
-        inc     a
-        ld      (ROM_MAPPER_REGISTER_1), a ; segment #n+1 (bank #n)
+        ld      (ROM_MAPPER_REGISTER_1), a ; segment #n (bank #n)
         ret
 
 ;------------------------------------------------
@@ -40,4 +39,4 @@ get_bank::
 ;------------------------------------------------
         .area   _DATA
 cur_bank:
-        .ds     1
+        .db     1

--- a/crt0/crt0_mod_rom_mapper/rom_ascii8.s
+++ b/crt0/crt0_mod_rom_mapper/rom_ascii8.s
@@ -4,10 +4,10 @@
 ;;;
 ;;; Copyright (c) 2021-2022 Daishi Mori (mori0091)
 ;;;
-;;; This software is released under the MIT License.
+;;; This software is released under the MIT License.\n
 ;;; See https://github.com/mori0091/libmsx/blob/main/LICENSE
 ;;;
-;;; GitHub libmsx project
+;;; GitHub libmsx project\n
 ;;; https://github.com/mori0091/libmsx
 
         .module crt0
@@ -25,20 +25,19 @@ rom_init::
         inc     a
         ld      (ROM_MAPPER_REGISTER_1), a ; segment #1
         inc     a
-        ld      (ROM_MAPPER_REGISTER_2), a ; segment #2 (bank #0.0)
+        ld      (ROM_MAPPER_REGISTER_2), a ; segment #2 (bank #1.0)
         inc     a
-        ld      (ROM_MAPPER_REGISTER_3), a ; segment #3 (bank #0.1)
+        ld      (ROM_MAPPER_REGISTER_3), a ; segment #3 (bank #1.1)
         ret
 
 ;------------------------------------------------
 set_bank::
         ld      (cur_bank), a
         ;; two 8KiB pages per one bank
-        inc     a
         add     a, a
-        ld      (ROM_MAPPER_REGISTER_2), a ; segment #2n+2 (lower 8KiB of bank #n)
+        ld      (ROM_MAPPER_REGISTER_2), a ; segment #2n+0 (lower 8KiB of bank #n)
         inc     a
-        ld      (ROM_MAPPER_REGISTER_3), a ; segment #2n+3 (upper 8KiB of bank #n)
+        ld      (ROM_MAPPER_REGISTER_3), a ; segment #2n+1 (upper 8KiB of bank #n)
         ret
 
 ;------------------------------------------------
@@ -49,4 +48,4 @@ get_bank::
 ;------------------------------------------------
         .area   _DATA
 cur_bank:
-        .ds     1
+        .db     1

--- a/include/bmem.h
+++ b/include/bmem.h
@@ -1,0 +1,176 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file bmem.h
+ * \brief Data types and functions for accessing banked memory.
+ * \ingroup BANKED_MEMORY
+ */
+/**
+ * \defgroup BANKED_MEMORY Banked Memory interface for MegaROM.
+ * `#include <bmem.h>`
+ *
+ * **MegaROM** is a ROM consisting of up to 256 8KiB or 16KiB segments.
+ *
+ * In `libmsx`, **MegaROM** is treated as **banked memory** consisting of one
+ * large address space (or a series of 16KiB segments).
+ *
+ * The first 16KiB segment is used as the `CODE` segment.
+ *
+ * Subsequent segments are named `BANK1`, `BANK2`, ..., and `BANK63`.
+ *
+ * The `CODE` segment is always placed on page 1 (0x4000..0x7fff) of its slot's
+ * address space.
+ *
+ * Page 2 (0x8000..0xbfff) is used as a switchable memory bank, and arbitrary
+ * 16KiB segment in **banked memory** can be placed on page 2.
+ *
+ * Functions marked `__banked` in banked memory can be called from `CODE`
+ * segments or other segments, see also SDCC Compiler User Manual "Bank
+ * Switching" and "Z80 banked calls".
+ *
+ * `bmem.h` provides other functions to use banked memory as data storage.
+ * - \ref BANKED_MEMORY_DIRECT_ACCESS
+ * - \ref BANKED_MEMORY_INDIRECT_ACCESS
+ *
+ * \note
+ * These functions are available only when the `CONFIG_ROM_TYPE` is `ascii8` or
+ * `ascii16`.
+ *
+ * @{
+ */
+
+#pragma once
+
+#include <stdint.h>
+#ifndef BMEM_H_
+#define BMEM_H_
+
+#include <vmem.h>
+
+/**
+ * \defgroup BANKED_MEMORY_DIRECT_ACCESS Direct access to banked memory by switching page 2.
+ * \ingroup BANKED_MEMORY
+ * APIs for direct access to 16KiB segments of banked memory.
+ *
+ * @{
+ */
+
+/**
+ * Type of an address of banked memory.
+ */
+typedef uint32_t bmemptr_t;
+
+/**
+ * Returns the segment number corresponding to the specified address of the
+ * banked memory.
+ *
+ * \return the segment number corresponding to `loc`.
+ */
+inline uint8_t bmem_bank_of(bmemptr_t loc) {
+  return (uint8_t)((loc >> 14) & 255);
+}
+
+/**
+ * Get the current segment number of banked memory at page 2 (0x8000..0xbfff).
+ *
+ * \return the current segment number.
+ */
+uint8_t bmem_get_bank(void) __naked;
+
+/**
+ * Expose a 16KiB segment of banked memory at page 2 (0x8000..0xbfff).
+ *
+ * \param bank the segment number.
+ */
+void bmem_set_bank(uint8_t bank) __naked;
+
+/** @} */
+
+/**
+ * \defgroup BANKED_MEMORY_INDIRECT_ACCESS Reading and copying from banked memory.
+ * \ingroup BANKED_MEMORY
+ * APIs for indirect access to banked memory.
+ *
+ * Banked memory is treated as a ROM with one large address space to read and
+ * copy data.
+ *
+ * @{
+ */
+
+/**
+ * Read byte from banked memory.
+ *
+ * \param src address of banked memory.
+ * \return a byte value.
+ */
+uint8_t bmem_get(bmemptr_t src);
+
+/**
+ * Read 16-bits value from banked memory.
+ *
+ * \param src address of banked memory.
+ * \return a 16-bits value.
+ */
+uint16_t bmem_get_u16(bmemptr_t src);
+
+/**
+ * Read byte sequence from banked memory.
+ *
+ * \param src source address of banked memory.
+ * \param dst destination address.
+ * \param len number of bytes to be read.
+ */
+void bmem_read(bmemptr_t src, void* dst, uint16_t len);
+
+/**
+ * Copy from banked memory to VRAM.
+ *
+ * \param src source address of banked memory.
+ * \param dst destination address of VRAM.
+ * \param len number of bytes to be copied.
+ */
+void bmem_copy_to_vmem(bmemptr_t src, vmemptr_t dst, uint32_t len);
+
+/**
+ * Load a `BSAVE` formatted binary in banked memory into VRAM.
+ *
+ * A `BSAVE` formatted binary must consist of a 7-byte header followed by the
+ * data body, as follows:
+ *
+ * | address       | contents                   |
+ * |---------------|----------------------------|
+ * | `src+0`       | `0xFE`                     |
+ * | `src+1`       | lo-byte of `start` address |
+ * | `src+2`       | hi-byte of `start` address |
+ * | `src+3`       | lo-byte of `end` address   |
+ * | `src+4`       | hi-byte of `end` address   |
+ * | `src+5`       | lo-byte of `run` address   |
+ * | `src+6`       | hi-byte of `run` address   |
+ * | `src+7`       | `body[0]`                  |
+ * | ...           | ...                        |
+ * | `src+7 + N-1` | `body[N-1]`                |
+ *
+ * where `N == end - start + 1`, and `start <= end`.
+ *
+ * `start` and `end` indicate the range of VRAM addresses where the image was;
+ * for VRAM images, `run` is not used.
+ *
+ * This function copies the data body to `start`..`end` of VRAM.
+ *
+ * \param src address of `BSAVE` foramtted binary in banked memory.
+ */
+void bmem_bload_s(bmemptr_t src);
+
+/** @} */
+
+#endif // BMEM_H_
+
+/** @} */

--- a/mk/ascii16.mk
+++ b/mk/ascii16.mk
@@ -2,10 +2,10 @@
 
 # Copyright (c) 2022 Daishi Mori (mori0091)
 #
-# This software is released under the MIT License.
+# This software is released under the MIT License.\n
 # See https://github.com/mori0091/libmsx/blob/main/LICENSE
 #
-# GitHub libmsx project
+# GitHub libmsx project\n
 # https://github.com/mori0091/libmsx
 
 # ------------------------------------------------------------------------
@@ -20,15 +20,15 @@
 #         |            |     segment names                           /   |            |
 # 0x04000 |------------|.....+------------+..........................   .|------------| 0x04000
 #         | page #1    |     | HEADER     |                            / | segment #1 |
-#         |            | --> | CODE       |                           /  |  (BANK0)   |
+#         |            | --> | CODE       |                           /  |  (BANK1)   |
 #         |            |     | etc.       |                          /   |            |
 # 0x08000 |------------|.....|------------+------------+------------+    |------------| 0x08000
-#         | page #2    |     | BANK0      | BANK1      | BANK2      |    | segment #2 |
-#         |            | --> |            |            |            |    |  (BANK1)   |
+#         | page #2    |     | BANK1      | BANK2      | BANK3      |    | segment #2 |
+#         |            | --> |            |            |            |    |  (BANK2)   |
 #         |            |     |            |            |            |    |            |
 # 0x0C000 |------------|.....+------------+------------+------------+    |------------| 0x0C000
 #         | page #3    |                                             .   | segment #3 |
-#         | RAM        | page #1 is mapped to segment #0 (always)     .  |  (BANK2)   |
+#         | RAM        | page #1 is mapped to segment #0 (always)     .  |  (BANK3)   |
 #         |            | page #2 is mapped to segment #1 (initially)   . |            |
 # 0x10000 +------------+ page #2 is used as 16 KiB banked ROM area      .|------------| 0x10000
 #

--- a/mk/ascii8.mk
+++ b/mk/ascii8.mk
@@ -2,10 +2,10 @@
 
 # Copyright (c) 2022 Daishi Mori (mori0091)
 #
-# This software is released under the MIT License.
+# This software is released under the MIT License.\n
 # See https://github.com/mori0091/libmsx/blob/main/LICENSE
 #
-# GitHub libmsx project
+# GitHub libmsx project\n
 # https://github.com/mori0091/libmsx
 
 # ------------------------------------------------------------------------
@@ -20,15 +20,15 @@
 #         |            |     segment names                           /   | segment #1 |
 # 0x04000 |------------|.....+------------+..........................   .|------------| 0x04000
 #         | page #1    |     | HEADER     |                            / | segment #2 |
-#         |            | --> | CODE       |                           /  |- (BANK0) --| 0x06000
+#         |            | --> | CODE       |                           /  |- (BANK1) --| 0x06000
 #         |            |     | etc.       |                          /   | segment #3 |
 # 0x08000 |------------|.....|------------+------------+------------+    |------------| 0x08000
-#         | page #2    |     | BANK0      | BANK1      | BANK2      |    | segment #4 |
-#         |            | --> |            |            |            |    |- (BANK1) --| 0x0A000
+#         | page #2    |     | BANK1      | BANK2      | BANK3      |    | segment #4 |
+#         |            | --> |            |            |            |    |- (BANK2) --| 0x0A000
 #         |            |     |            |            |            |    | segment #5 |
 # 0x0C000 |------------|.....+------------+------------+------------+    |------------| 0x0C000
 #         | page #3    |                                             .   | segment #6 |
-#         | RAM        | page #1 is mapped to segment #0-1 (always)   .  |- (BANK2) --| 0x0E000
+#         | RAM        | page #1 is mapped to segment #0-1 (always)   .  |- (BANK3) --| 0x0E000
 #         |            | page #2 is mapped to segment #2-3 (initially) . | segment #7 |
 # 0x10000 +------------+ page #2 is used as 16 KiB banked ROM area      .|------------| 0x10000
 #

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -1,27 +1,12 @@
 # -*- coding: utf-8-unix; tab-width: 8 -*-
 
-# Copyright (c) 2021 Daishi Mori (mori0091)
+# Copyright (c) 2021-2022 Daishi Mori (mori0091)
 #
-# This software is released under the MIT License.
+# This software is released under the MIT License.\n
 # See https://github.com/mori0091/libmsx/blob/main/LICENSE
 #
-# GitHub libmsx project
+# GitHub libmsx project\n
 # https://github.com/mori0091/libmsx
-
-# LIBMSX_HOME = ./libmsx
-#
-# NAME = foo
-#
-# CFLAGS  = -DNDEBUG
-# LDFLAGS =
-# LDLIBS  =
-#
-# IMAGE_SIZE = 32768
-# ADDR_HEAD = 0x4000
-# ADDR_CODE = 0x4020
-# ADDR_DATA = 0xc000
-# CRT0 = ${LIBMSX_HOME}/lib/32k.4000/crt0.rel
-
 
 .PHONY: all build clean libmsx
 
@@ -82,23 +67,135 @@ ifneq (${CONFIG_CRT0_MOD_ROM_HEADER}, app_megarom_header)
 IHX2BIN_FLAGS = -s ${IMAGE_SIZE} -b ${ADDR_HEAD}
 else
 LDFLAGS += \
-	-Wl-b_BANK0=0x08000 \
 	-Wl-b_BANK1=0x18000 \
 	-Wl-b_BANK2=0x28000 \
 	-Wl-b_BANK3=0x38000 \
 	-Wl-b_BANK4=0x48000 \
 	-Wl-b_BANK5=0x58000 \
-	-Wl-b_BANK6=0x68000
+	-Wl-b_BANK6=0x68000 \
+	-Wl-b_BANK7=0x78000 \
+	-Wl-b_BANK8=0x88000 \
+	-Wl-b_BANK9=0x98000 \
+	-Wl-b_BANK10=0xa8000 \
+	-Wl-b_BANK11=0xb8000 \
+	-Wl-b_BANK12=0xc8000 \
+	-Wl-b_BANK13=0xd8000 \
+	-Wl-b_BANK14=0xe8000 \
+	-Wl-b_BANK15=0xf8000 \
+	-Wl-b_BANK16=0x108000 \
+	-Wl-b_BANK17=0x118000 \
+	-Wl-b_BANK18=0x128000 \
+	-Wl-b_BANK19=0x138000 \
+	-Wl-b_BANK20=0x148000 \
+	-Wl-b_BANK21=0x158000 \
+	-Wl-b_BANK22=0x168000 \
+	-Wl-b_BANK23=0x178000 \
+	-Wl-b_BANK24=0x188000 \
+	-Wl-b_BANK25=0x198000 \
+	-Wl-b_BANK26=0x1a8000 \
+	-Wl-b_BANK27=0x1b8000 \
+	-Wl-b_BANK28=0x1c8000 \
+	-Wl-b_BANK29=0x1d8000 \
+	-Wl-b_BANK30=0x1e8000 \
+	-Wl-b_BANK31=0x1f8000 \
+	-Wl-b_BANK32=0x208000 \
+	-Wl-b_BANK33=0x218000 \
+	-Wl-b_BANK34=0x228000 \
+	-Wl-b_BANK35=0x238000 \
+	-Wl-b_BANK36=0x248000 \
+	-Wl-b_BANK37=0x258000 \
+	-Wl-b_BANK38=0x268000 \
+	-Wl-b_BANK39=0x278000 \
+	-Wl-b_BANK40=0x288000 \
+	-Wl-b_BANK41=0x298000 \
+	-Wl-b_BANK42=0x2a8000 \
+	-Wl-b_BANK43=0x2b8000 \
+	-Wl-b_BANK44=0x2c8000 \
+	-Wl-b_BANK45=0x2d8000 \
+	-Wl-b_BANK46=0x2e8000 \
+	-Wl-b_BANK47=0x2f8000 \
+	-Wl-b_BANK48=0x308000 \
+	-Wl-b_BANK49=0x318000 \
+	-Wl-b_BANK50=0x328000 \
+	-Wl-b_BANK51=0x338000 \
+	-Wl-b_BANK52=0x348000 \
+	-Wl-b_BANK53=0x358000 \
+	-Wl-b_BANK54=0x368000 \
+	-Wl-b_BANK55=0x378000 \
+	-Wl-b_BANK56=0x388000 \
+	-Wl-b_BANK57=0x398000 \
+	-Wl-b_BANK58=0x3a8000 \
+	-Wl-b_BANK59=0x3b8000 \
+	-Wl-b_BANK60=0x3c8000 \
+	-Wl-b_BANK61=0x3d8000 \
+	-Wl-b_BANK62=0x3e8000 \
+	-Wl-b_BANK63=0x3f8000
 
 IHX2BIN_FLAGS = -s ${IMAGE_SIZE} -b ${ADDR_HEAD} \
 		-s 16384			 \
-		-b 0x08000			 \
 		-b 0x18000			 \
 		-b 0x28000			 \
 		-b 0x38000			 \
 		-b 0x48000			 \
 		-b 0x58000			 \
 		-b 0x68000			 \
+		-b 0x78000			 \
+		-b 0x88000			 \
+		-b 0x98000			 \
+		-b 0xa8000			 \
+		-b 0xb8000			 \
+		-b 0xc8000			 \
+		-b 0xd8000			 \
+		-b 0xe8000			 \
+		-b 0xf8000			 \
+		-b 0x108000			 \
+		-b 0x118000			 \
+		-b 0x128000			 \
+		-b 0x138000			 \
+		-b 0x148000			 \
+		-b 0x158000			 \
+		-b 0x168000			 \
+		-b 0x178000			 \
+		-b 0x188000			 \
+		-b 0x198000			 \
+		-b 0x1a8000			 \
+		-b 0x1b8000			 \
+		-b 0x1c8000			 \
+		-b 0x1d8000			 \
+		-b 0x1e8000			 \
+		-b 0x1f8000			 \
+		-b 0x208000			 \
+		-b 0x218000			 \
+		-b 0x228000			 \
+		-b 0x238000			 \
+		-b 0x248000			 \
+		-b 0x258000			 \
+		-b 0x268000			 \
+		-b 0x278000			 \
+		-b 0x288000			 \
+		-b 0x298000			 \
+		-b 0x2a8000			 \
+		-b 0x2b8000			 \
+		-b 0x2c8000			 \
+		-b 0x2d8000			 \
+		-b 0x2e8000			 \
+		-b 0x2f8000			 \
+		-b 0x308000			 \
+		-b 0x318000			 \
+		-b 0x328000			 \
+		-b 0x338000			 \
+		-b 0x348000			 \
+		-b 0x358000			 \
+		-b 0x368000			 \
+		-b 0x378000			 \
+		-b 0x388000			 \
+		-b 0x398000			 \
+		-b 0x3a8000			 \
+		-b 0x3b8000			 \
+		-b 0x3c8000			 \
+		-b 0x3d8000			 \
+		-b 0x3e8000			 \
+		-b 0x3f8000			 \
 		--pow2
 endif
 
@@ -183,11 +280,15 @@ endif
 
 ${CRT0} ${LIBMSX}: libmsx
 
-%.rom: %.ihx
+%.bin: %.ihx
 	@${info [Build]	$@}
 	@${IHX2BIN} ${IHX2BIN_FLAGS} -o $@ $<
 
-%.dat: %.ihx
+${BINDIR}/${NAME}.rom: ${BINDIR}/${NAME}.bin ${RSCS}
+	@${info [Build]	$@ <- $^}
+	@cat $^ > $@ && truncate -s %16K $@
+
+${BINDIR}/${NAME}.dat: ${BINDIR}/${NAME}.ihx
 	@${info [Build]	$@}
 	@${IHX2BIN} -o $@ $<
 

--- a/sample/megarom/src/bank1/game_main.c
+++ b/sample/megarom/src/bank1/game_main.c
@@ -7,11 +7,11 @@
  * This software is released under the MIT License.
  * See https://github.com/mori0091/libmsx/blob/main/LICENSE
  *
- * GitHub libmsx project
+ * GitHub libmsx project\n
  * https://github.com/mori0091/libmsx
  */
 
-#pragma codeseg BANK0
+#pragma codeseg BANK1
 
 #include <msx.h>
 

--- a/sample/megarom/src/bank2/boot_main.c
+++ b/sample/megarom/src/bank2/boot_main.c
@@ -11,7 +11,7 @@
  * https://github.com/mori0091/libmsx
  */
 
-#pragma codeseg BANK1
+#pragma codeseg BANK2
 
 #include "boot_main.h"
 #include "macros.h"

--- a/src/bmem_bload_s.c
+++ b/src/bmem_bload_s.c
@@ -1,0 +1,25 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file bmem_bload_s.c
+ */
+
+#include "bmem.h"
+
+void bmem_bload_s(bmemptr_t src) {
+  if (bmem_get(src) == 0xfe) {
+    uint16_t beg = bmem_get_u16(src+1);
+    uint16_t end = bmem_get_u16(src+3);
+    if (beg < end) {
+      bmem_copy_to_vmem(src+7, (vmemptr_t)beg, (uint32_t)end - beg + 1);
+    }
+  }
+}

--- a/src/bmem_copy_to_vmem.c
+++ b/src/bmem_copy_to_vmem.c
@@ -1,0 +1,39 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file bmem_copy_to_vmem.c
+ */
+
+#include "bmem.h"
+
+void bmem_copy_to_vmem(bmemptr_t src, vmemptr_t dst, uint32_t len) {
+  uint8_t bank = bmem_bank_of(src);
+  const uint16_t offset = (uint16_t)(src & 0x3fff);
+  const uint8_t * p = (const uint8_t *)0x8000 + offset;
+  uint32_t n = (uint32_t)0x4000 - offset;
+
+  const uint8_t old_bank = bmem_get_bank();
+  vmem_set_write_address(dst);
+  while (len) {
+    if (len < n) {
+      n = len;
+    }
+    len -= n;
+    bmem_set_bank(bank);
+    while (n--) {
+      vmem_set(*p++);
+    }
+    bank++;
+    p = (const uint8_t *)0x8000;
+    n = (uint32_t)0x4000;
+  }
+  bmem_set_bank(old_bank);
+}

--- a/src/bmem_get.c
+++ b/src/bmem_get.c
@@ -1,0 +1,24 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file bmem_get.c
+ */
+
+#include "bmem.h"
+
+uint8_t bmem_get(bmemptr_t src) {
+  const uint8_t old_bank = bmem_get_bank();
+  uint8_t bank = bmem_bank_of(src);
+  bmem_set_bank(bank);
+  uint8_t ret = *(const uint8_t *)(const uintptr_t)((src & 0x3fff) + 0x8000);
+  bmem_set_bank(old_bank);
+  return ret;
+}

--- a/src/bmem_get_bank.c
+++ b/src/bmem_get_bank.c
@@ -1,0 +1,19 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file bmem_get_bank.c
+ */
+
+#include "bmem.h"
+
+uint8_t bmem_get_bank(void) __naked {
+  __asm__("jp get_bank");
+}

--- a/src/bmem_get_u16.c
+++ b/src/bmem_get_u16.c
@@ -1,0 +1,19 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file bmem_get_u16.c
+ */
+
+#include "bmem.h"
+
+uint16_t bmem_get_u16(bmemptr_t src) {
+  return bmem_get(src) | ((uint16_t)bmem_get(src + 1) << 8);
+}

--- a/src/bmem_read.c
+++ b/src/bmem_read.c
@@ -1,0 +1,39 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file bmem_read.c
+ */
+
+#include "bmem.h"
+
+#include <string.h>
+
+void bmem_read(bmemptr_t src, void* dst, uint16_t len) {
+  uint8_t bank = bmem_bank_of(src);
+  const uint16_t offset = (uint16_t)(src & 0x3fff);
+  const uint8_t * p = (const uint8_t *)0x8000 + offset;
+  uint16_t n = (uint16_t)0x4000 - offset;
+
+  const uint8_t old_bank = bmem_get_bank();
+  while (len) {
+    if (len < n) {
+      n = len;
+    }
+    len -= n;
+    bmem_set_bank(bank);
+    memcpy(dst, p, n);
+    dst = (uint8_t *)dst + n;
+    bank++;
+    p = (const uint8_t *)0x8000;
+    n = 0x4000;
+  }
+  bmem_set_bank(old_bank);
+}

--- a/src/bmem_set_bank.c
+++ b/src/bmem_set_bank.c
@@ -1,0 +1,20 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2022 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file bmem_get_bank.c
+ */
+
+#include "bmem.h"
+
+void bmem_set_bank(uint8_t bank) __naked {
+  (void)bank;
+  __asm__("jp set_bank");
+}


### PR DESCRIPTION
**BREAKING CHANGE**
- Removed `BANK0`.
- Reordered offset of each `BANK<n>` in ROM image.

**NEW FEATURE**
- Up to 64 Banks (`CODE`, `BANK1` to `BANK63`) are available.
- Added "Direct access to banked memory by switching page 2"
- Added "Reading and copying form banked memory"
