### PR TITLE
fix(tools): ridxc.sh: code to be generated

### DIFF
--- a/tools/ridxc.sh
+++ b/tools/ridxc.sh
@@ -22,7 +22,7 @@ list () {
     find "${resources_dir}" -type f -printf '%s\t%P\n' |
         while read s n;
         do
-            printf '  {0x%08XL, %8dL, \"%s\"},\n' "${offset}" "${s}" "${n}";
+            printf '  {0x%08XUL, %8dUL, "%s"},\n' "${offset}" "${s}" "${n}";
             offset=$((offset + s));
         done
 }


### PR DESCRIPTION
Fixed code generated by `tools/ridxc.sh` couldn't compile with SDCC 4.2.0 for Linux. (Removed needless backslash.)

Changed suffix of `.offset` and `.size` from `L` to `UL`.