### PR TITLE
Fix(bmem)

### DIFF
--- a/include/workarea.h
+++ b/include/workarea.h
@@ -240,6 +240,11 @@ static volatile __at (0xfb20) uint8_t HOKVLD; ///< `MSX` Extended BIOS flag.
  */
 static volatile __at (0xfb21) uint8_t DRVTBL[8];
 
+/**
+ * `MSX` The highest address of free area (bottom of stack).
+ */
+static volatile __at (0xfc4a) uint16_t HIMEM;
+
 // ---- Data for `PLAY` statement ----
 // fb35 .. fbaf
 

--- a/src/bmem_read.c
+++ b/src/bmem_read.c
@@ -13,6 +13,7 @@
  */
 
 #include "bmem.h"
+#include "workarea.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -33,7 +34,7 @@ void bmem_read(bmemptr_t src, void* dst, uint16_t len) {
   // area specified by `dst` and `len`. Unfortunately, however, the library
   // cannot determine the appropriate bounds. The application programmer must
   // deal with this.
-  if ((uintptr_t)q < 0xc000 || len < ~((uintptr_t)q)) {
+  if ((uintptr_t)q < 0xc000 || HIMEM <= (uintptr_t)q || (int16_t)(HIMEM - (uintptr_t)q) < len) {
     return;
   }
 


### PR DESCRIPTION
`bmem_read()`: Fixed range check of copy destination.
`workarea.h`: Added `HIMEM` that holds the highest address of free area (bottom of stack).