### PR TITLE
Fix(snddrv)

### DIFF
--- a/src/snd_m.c
+++ b/src/snd_m.c
@@ -62,6 +62,7 @@ static void snd_m__set_Pattern(struct snd_m_ctx * ctx, const snd_Music * pg, con
     ctx->spd.skip_count = 0;
     ctx->timer = 0;
   }
+  ctx->line = 0;
 }
 
 static void snd_m__update(struct snd_m_ctx * ctx);
@@ -90,7 +91,6 @@ void snd_m__decode(struct snd_m_ctx * ctx) {
     const snd_Pattern * p = &pg->patterns.data[ctx->pindex];
     if (p->height <= ctx->line) {
       // Proceed to the next pattern
-      ctx->line = 0;
       ctx->pindex++;
       p++;
       if (pg->patterns.length <= ctx->pindex) {

--- a/src/snd_m.c
+++ b/src/snd_m.c
@@ -95,14 +95,20 @@ void snd_m__decode(struct snd_m_ctx * ctx) {
       p++;
       if (pg->patterns.length <= ctx->pindex) {
         // End of the list of patterns
-        if (!pg->isLoop) {
-          // finish the program (unless 'auto-repeat' is set)
+        if (!ctx->repeat) {
+          // finish the program
           ctx->isEnd = true;
           return;
         }
-        // Loop back to the specified pattern
-        // assert(pg->loopToIndex < pg->patterns.length);
-        ctx->pindex = pg->loopToIndex;
+        if (!pg->isLoop) {
+          // Loop back to the first pattern
+          ctx->pindex = 0;
+        }
+        else {
+          // Loop back to the specified pattern
+          // assert(pg->loopToIndex < pg->patterns.length);
+          ctx->pindex = pg->loopToIndex;
+        }
         p = &pg->patterns.data[ctx->pindex];
       }
       snd_m__set_Pattern(ctx, pg, p);

--- a/src/snd_m.h
+++ b/src/snd_m.h
@@ -31,6 +31,7 @@ struct snd_m_ctx {
   uint8_t wait;
   uint8_t timer;
   bool isEnd;
+  bool repeat;
   // ----
   struct {                      // Sequencer for snd_Music
     const snd_SoundAssets * sa; // pointer to the current sound assets

--- a/src/snddrv.c
+++ b/src/snddrv.c
@@ -26,7 +26,6 @@
 #define PSG(reg)                     (ay_3_8910_buffer[(reg)])
 
 static bool paused;
-static bool repeat;
 static uint8_t vsync_freq;
 uint8_t snd_speed_multiplier;
 
@@ -57,7 +56,7 @@ static void snd__pause(void) {
 }
 
 static void snd__set_repeat(bool status) {
-  repeat = status;
+  snd_bgm.m.repeat = status;
 }
 
 static void snd__init(void) {
@@ -167,16 +166,7 @@ void snd_play(void) {
     return;
   }
   ay_3_8910_play();
-
   snd_decode();
-
-  if (snd_bgm.m.isEnd && repeat) {
-    if (snd_bgm.m.music) {
-      uint8_t freq = snd_bgm.play_freq;
-      snd__set_bgm(snd_bgm.m.music);
-      snd_bgm.play_freq = freq;
-    }
-  }
 }
 
 // ------------------------------------------------


### PR DESCRIPTION
fixed `snd_set_repeat()`.
`snd_set_repeat(false)` should force to do not repeat BGM even if the BGM data is looped.
`snd_set_repeat(true)` should force to repeat BGM even if the BGM data is not looped.
If `snd_set_repeat()` was never called, the default behaviour is same as `snd_set_repeat(false)`.