### PR TITLE
fix(vmem): #55 vmem_write() doesn't work correctly in MSX1

### DIFF
--- a/src/vmem_read.c
+++ b/src/vmem_read.c
@@ -1,23 +1,24 @@
 // -*- coding: utf-8-unix -*-
-/**
- * \file vmem_read.c
- *
+/*
  * Copyright (c) 2021-2023 Daishi Mori (mori0091)
  *
- * This software is released under the MIT License.
+ * This software is released under the MIT License.\n
  * See https://github.com/mori0091/libmsx/blob/main/LICENSE
  *
- * GitHub libmsx project
+ * GitHub libmsx project\n
  * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file vmem_read.c
  */
 
 #include "../include/vdp.h"
 
 #include "vdp_internal.h"
 
+void vmem_read_chunk(uint8_t * p, uint16_t n);
+
 void vmem_read(vmemptr_t src, void* dst, uint16_t len) {
   vmem_set_read_address(src);
-  for (uint8_t* p = dst; len--; ) {
-    *p++ = VDP_GET_VMEM_VALUE();
-  }
+  vmem_read_chunk(dst, len);
 }

--- a/src/vmem_read_chunk.c
+++ b/src/vmem_read_chunk.c
@@ -1,0 +1,87 @@
+// -*- coding: utf-8-unix -*-
+/*
+ * Copyright (c) 2021-2023 Daishi Mori (mori0091)
+ *
+ * This software is released under the MIT License.\n
+ * See https://github.com/mori0091/libmsx/blob/main/LICENSE
+ *
+ * GitHub libmsx project\n
+ * https://github.com/mori0091/libmsx
+ */
+/**
+ * \file vmem_read_chunk.c
+ */
+
+#include "../include/vdp.h"
+
+#if (__SDCCCALL == 1)
+
+void vmem_read_chunk_1(uint8_t * p, uint16_t n) {
+  (void)p;                      // -> HL
+  (void)n;                      // -> DE
+  __asm__("        ld  c, #0x98");
+  __asm__("        ld  a, d");
+  __asm__("        or  a");
+  __asm__("        jr  z, 00002$");
+  __asm__("        ld  b, #0");
+  __asm__("00001$: ini");            // 16 states
+  __asm__("        jr  nz, 00001$"); // 12 or 7 states
+  __asm__("        dec d");
+  __asm__("        jr  nz, 00001$");
+  __asm__("00002$: ld  b, e");
+  __asm__("        ld  a, b");
+  __asm__("        or  a");
+  __asm__("        ret z");
+  __asm__("00003$: ini");
+  __asm__("        jr  nz, 00003$");
+}
+
+void vmem_read_chunk_2(uint8_t * p, uint16_t n) {
+  (void)p;                      // -> HL
+  (void)n;                      // -> DE
+  __asm__("        ld  c, #0x98");
+  __asm__("        ld  a, d");
+  __asm__("        or  a");
+  __asm__("        jr  z, 00002$");
+  __asm__("        ld  b, #0");
+  __asm__("00001$: inir");      // 21 or 16 states
+  __asm__("        dec d");
+  __asm__("        jr  nz, 00001$");
+  __asm__("00002$: ld  b, e");
+  __asm__("        ld  a, b");
+  __asm__("        or  a");
+  __asm__("        ret z");
+  __asm__("        inir");
+}
+
+#include "./vdp_internal.h"
+
+// See also https://www.msx.org/wiki/VRAM_access_speed
+void vmem_read_chunk(uint8_t * p, uint16_t n) {
+  // Force Z80 mode to avoid excessive waiting time inserted by S1990.
+  // (i.e. Z80 mode is faster than R800 mode in this case!)
+  const uint8_t cpu = msx_get_cpu_mode();
+  msx_set_cpu_mode(0x00);
+
+  if (sprite_mode < 2) {
+    // for MSX1 compatible screen mode and MSX2 TEXT 2 mode.
+    // (Requires 28? or 29 cycle for VDP port access.)
+    vmem_read_chunk_1(p, n);
+  }
+  else {
+    // for GRAPHIC 3, 4, 5, 6, 7 mode
+    vmem_read_chunk_2(p, n);
+  }
+
+  msx_set_cpu_mode(cpu);
+}
+
+#else
+
+void vmem_read_chunk(uint8_t * p, uint16_t n) {
+  while (n--) {
+    *p++ = vmem_get();
+  }
+}
+
+#endif

--- a/src/vmem_write_chunk.c
+++ b/src/vmem_write_chunk.c
@@ -16,7 +16,7 @@
 
 #if (__SDCCCALL == 1)
 
-void vmem_write_chunk(const uint8_t * p, uint16_t n) {
+void vmem_write_chunk_1(const uint8_t * p, uint16_t n) {
   (void)p;                      // -> HL
   (void)n;                      // -> DE
   __asm__("        ld  c, #0x98");
@@ -24,7 +24,28 @@ void vmem_write_chunk(const uint8_t * p, uint16_t n) {
   __asm__("        or  a");
   __asm__("        jr  z, 00002$");
   __asm__("        ld  b, #0");
-  __asm__("00001$: otir");
+  __asm__("00001$: outi");           // 16 states
+  __asm__("        jr  nz, 00001$"); // 12 or 7 states
+  __asm__("        dec d");
+  __asm__("        jr  nz, 00001$");
+  __asm__("00002$: ld  b, e");
+  __asm__("        ld  a, b");
+  __asm__("        or  a");
+  __asm__("        ret z");
+  // __asm__("        otir");
+  __asm__("00003$: outi");
+  __asm__("        jr  nz, 00003$");
+}
+
+void vmem_write_chunk_2(const uint8_t * p, uint16_t n) {
+  (void)p;                      // -> HL
+  (void)n;                      // -> DE
+  __asm__("        ld  c, #0x98");
+  __asm__("        ld  a, d");
+  __asm__("        or  a");
+  __asm__("        jr  z, 00002$");
+  __asm__("        ld  b, #0");
+  __asm__("00001$: otir");      // 21 or 16 states
   __asm__("        dec d");
   __asm__("        jr  nz, 00001$");
   __asm__("00002$: ld  b, e");
@@ -32,6 +53,28 @@ void vmem_write_chunk(const uint8_t * p, uint16_t n) {
   __asm__("        or  a");
   __asm__("        ret z");
   __asm__("        otir");
+}
+
+#include "./vdp_internal.h"
+
+// See also https://www.msx.org/wiki/VRAM_access_speed
+void vmem_write_chunk(const uint8_t * p, uint16_t n) {
+  // Force Z80 mode to avoid excessive waiting time inserted by S1990.
+  // (i.e. Z80 mode is faster than R800 mode in this case!)
+  const uint8_t cpu = msx_get_cpu_mode();
+  msx_set_cpu_mode(0x00);
+
+  if (sprite_mode < 2) {
+    // for MSX1 compatible screen mode and MSX2 TEXT 2 mode.
+    // (Requires 28? or 29 cycle for VDP port access.)
+    vmem_write_chunk_1(p, n);
+  }
+  else {
+    // for GRAPHIC 3, 4, 5, 6, 7 mode
+    vmem_write_chunk_2(p, n);
+  }
+
+  msx_set_cpu_mode(cpu);
 }
 
 #else

--- a/src/vmem_write_chunk.c
+++ b/src/vmem_write_chunk.c
@@ -32,7 +32,6 @@ void vmem_write_chunk_1(const uint8_t * p, uint16_t n) {
   __asm__("        ld  a, b");
   __asm__("        or  a");
   __asm__("        ret z");
-  // __asm__("        otir");
   __asm__("00003$: outi");
   __asm__("        jr  nz, 00003$");
 }


### PR DESCRIPTION
Fixed `vmem_write()` (`vmem_write_chunk()`) to work correctly in MSX1.
And improved to avoid excessive waiting time in MSXturboR R800 mode.
Same improvements are applied for `vmem_read()` also.

See also https://www.msx.org/wiki/VRAM_access_speed